### PR TITLE
parse GLONASS nmea sentences

### DIFF
--- a/rosflight_utils/src/libnmea_navsat_driver/parser.py
+++ b/rosflight_utils/src/libnmea_navsat_driver/parser.py
@@ -126,7 +126,7 @@ parse_maps = {
 
 def parse_nmea_sentence(nmea_sentence):
     # Check for a valid nmea sentence
-    if not re.match('^\$G*.*\*[0-9A-Fa-f]{2}$', nmea_sentence):
+    if not re.match('(^\$GP|^\$GN|^\$GL).*\*[0-9A-Fa-f]{2}$', nmea_sentence):
         logger.debug("Regex didn't match, sentence not valid NMEA? Sentence was: %s"
                      % repr(nmea_sentence))
         return False


### PR DESCRIPTION
This just adds the most recent commit from the [nmea_navsat_driver](https://github.com/ros-drivers/nmea_navsat_driver/commit/904ea247aa0c5305facf71811defc846394b28d3) which adds support for GLONASS nmea sentences (like those that the ublox m8 produces).  How it is now I think works fine, but is less robust.

I've tested the changes with an m8 GPS and it works as expected
