### PR TITLE
Add enum values to the GNSS message, for readability

### DIFF
--- a/rosflight_msgs/msg/GNSS.msg
+++ b/rosflight_msgs/msg/GNSS.msg
@@ -1,5 +1,5 @@
 Header header # Estimated ROS time at moment of measurement
-uint8 fix # fix type, as defined in the UBX protocol
+uint8 fix # fix type, as defined in the UBX protocol, enums defined below
 time time # GPS time at moment of measurement
 float64[3] position # m, ECEF frame
 float64 horizontal_accuracy # m
@@ -7,3 +7,9 @@ float64 vertical_accuracy # m
 float64[3] velocity # m/s, ECEF frame
 float64 speed_accuracy # m/s
 
+uint8 FIX_TYPE_NO_FIX = 0 
+uint8 FIX_TYPE_DEAD_RECKONING = 1
+uint8 FIX_TYPE_2D = 2
+uint8 FIX_TYPE_3D = 3 
+uint8 FIX_TYPE_GPS_AND_DEAD_RECKONING = 4
+uint8 FIX_TYPE_TIME_ONLY = 5


### PR DESCRIPTION
The fix type field in the GNSS message is taken from the UBX protocol. This currently requires users to refer to the UBX protocol to understand this field. This request adds enum values to the message, which will allow for easier and cleaner programming. The message itself is unchanged, so this will not break compatibility. The enum fields were taken from UBX read.
