### PR TITLE
Change default port to /dev/ttyACM0 to match the revo

### DIFF
--- a/rosflight/src/rosflight_io.cpp
+++ b/rosflight/src/rosflight_io.cpp
@@ -81,7 +81,7 @@ rosflightIO::rosflightIO()
   }
   else
   {
-    std::string port = nh_private.param<std::string>("port", "/dev/ttyUSB0");
+    std::string port = nh_private.param<std::string>("port", "/dev/ttyACM0");
     int baud_rate = nh_private.param<int>("baud_rate", 921600);
 
     ROS_INFO("Connecting to serial port \"%s\", at %d baud", port.c_str(), baud_rate);


### PR DESCRIPTION
Changes the default port to /dev/ttyACM0, because the revo uses that, and nazes are deprecated.
