### PR TITLE
Added missing break statement

### DIFF
--- a/rosflight/src/rosflight_io.cpp
+++ b/rosflight/src/rosflight_io.cpp
@@ -203,6 +203,7 @@ void rosflightIO::handle_mavlink_message(const mavlink_message_t &msg)
       break;
     case MAVLINK_MSG_ID_ROSFLIGHT_BATTERY_STATUS:
       handle_battery_status_msg(msg);
+      break;
     default:
       ROS_DEBUG("rosflight_io: Got unhandled mavlink message ID %d", msg.msgid);
       break;


### PR DESCRIPTION
This was causing "Got unhandled mavlink message ID 199" debug messages to be
printed erroneously.