### PR TITLE
Smoother serial

### DIFF
--- a/rosflight/CMakeLists.txt
+++ b/rosflight/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rosflight)
 
-set(CMAKE_BUILD_TYPE Release)
+set(CMAKE_BUILD_TYPE Debug)
 
 message("CMAKE_C_FLAGS_RELEASE is ${CMAKE_C_FLAGS_RELEASE}")
 

--- a/rosflight/include/rosflight/mavrosflight/mavlink_comm.h
+++ b/rosflight/include/rosflight/mavrosflight/mavlink_comm.h
@@ -171,6 +171,11 @@ private:
    */
   void async_write_end(const boost::system::error_code& error, size_t bytes_transferred);
 
+  /**
+   * \brief Notifies all listeners that the connection has been broken
+   */
+  void notify_disconnect();
+
   //===========================================================================
   // member variables
   //===========================================================================

--- a/rosflight/include/rosflight/mavrosflight/mavlink_listener_interface.h
+++ b/rosflight/include/rosflight/mavrosflight/mavlink_listener_interface.h
@@ -54,6 +54,7 @@ public:
    * \param msg The mavlink message to handle
    */
   virtual void handle_mavlink_message(const mavlink_message_t &msg) = 0;
+  virtual void on_mavlink_disconnect(){};
 };
 
 } // namespace mavrosflight

--- a/rosflight/include/rosflight/rosflight_io.h
+++ b/rosflight/include/rosflight/rosflight_io.h
@@ -96,6 +96,7 @@ public:
   ~rosflightIO();
 
   virtual void handle_mavlink_message(const mavlink_message_t &msg);
+  virtual void on_mavlink_disconnect() override;
 
   virtual void on_new_param_received(std::string name, double value);
   virtual void on_param_value_updated(std::string name, double value);

--- a/rosflight/include/rosflight/rosflight_io.h
+++ b/rosflight/include/rosflight/rosflight_io.h
@@ -162,6 +162,11 @@ private:
     return value < min ? min : (value > max ? max : value);
   }
 
+  // parameters
+  bool wait_for_serial_{false};
+  float serial_check_period_s_{1.0};
+
+
 
   ros::NodeHandle nh_;
 

--- a/rosflight/src/mavrosflight/mavlink_comm.cpp
+++ b/rosflight/src/mavrosflight/mavlink_comm.cpp
@@ -68,6 +68,7 @@ void MavlinkComm::close()
   io_service_.stop();
   do_close();
 
+  notify_disconnect();
 }
 
 void MavlinkComm::register_mavlink_listener(MavlinkListenerInterface * const listener)
@@ -139,6 +140,11 @@ void MavlinkComm::async_read_end(const boost::system::error_code &error, size_t 
   }
 
   async_read();
+}
+void MavlinkComm::notify_disconnect()
+{
+  for(MavlinkListenerInterface *listener: listeners_)
+    listener->on_mavlink_disconnect();
 }
 
 void MavlinkComm::send_message(const mavlink_message_t &msg)

--- a/rosflight/src/mavrosflight/mavlink_comm.cpp
+++ b/rosflight/src/mavrosflight/mavlink_comm.cpp
@@ -68,10 +68,6 @@ void MavlinkComm::close()
   io_service_.stop();
   do_close();
 
-  if (io_thread_.joinable())
-  {
-    io_thread_.join();
-  }
 }
 
 void MavlinkComm::register_mavlink_listener(MavlinkListenerInterface * const listener)

--- a/rosflight/src/rosflight_io.cpp
+++ b/rosflight/src/rosflight_io.cpp
@@ -228,6 +228,12 @@ void rosflightIO::handle_mavlink_message(const mavlink_message_t &msg)
   }
 }
 
+void rosflightIO::on_mavlink_disconnect()
+{
+  ROS_FATAL("Connection to firmware lost. Shutting down.");
+  ros::shutdown();
+}
+
 void rosflightIO::on_new_param_received(std::string name, double value)
 {
   ROS_DEBUG("Got parameter %s with value %g", name.c_str(), value);


### PR DESCRIPTION
Improves performance with serial connections:

- Adds parameters `~wait_for_serial` and `~serial_check_period`. If `~wait_for_serial` is set to true, and the serial port is not available when the node comes up, it will wait `~serial_check_period` seconds and then try again, until the node is killed or connects.
- When the serial connection is lost, displays an error message so stating, and closes gracefully, instead of a thread error.
- I'm considering adding the ability to automatically reconnect on a lost connection.