### PR TITLE
Make buildfarm CMake happy

### DIFF
--- a/rosflight_firmware/CMakeLists.txt
+++ b/rosflight_firmware/CMakeLists.txt
@@ -27,11 +27,11 @@ execute_process(COMMAND git describe --tags --abbrev=8 --always --dirty --long
     OUTPUT_STRIP_TRAILING_WHITESPACE
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/firmware)
 
-if("${GIT_VERSION_STRING}" STREQUAL "")
+if(GIT_VERSION_STRING STREQUAL "")
   set(GIT_VERSION_STRING "undefined")
 endif()
 
-if("${GIT_VERSION_HASH}" STREQUAL "")
+if(GIT_VERSION_HASH STREQUAL "")
   set(GIT_VERSION_HASH "0")
 endif()
 


### PR DESCRIPTION
Trying to get rid of a CMake warning that causes the ROS buildfarm PR testing to fail
