### PR TITLE
Better rc failsafe sim

### DIFF
--- a/rosflight_sim/include/rosflight_sim/sil_board.h
+++ b/rosflight_sim/include/rosflight_sim/sil_board.h
@@ -106,20 +106,21 @@ private:
   gazebo::physics::ModelPtr model_;
   gazebo::physics::LinkPtr link_;
 
-  ros::NodeHandle* nh_;
+  ros::NodeHandle *nh_;
   ros::Subscriber rc_sub_;
   rosflight_msgs::RCRaw latestRC_;
+  ros::Time last_rc_message_timestamp_;
   bool rc_received_;
 
   std::string mav_type_;
-  int pwm_outputs_[14];  //assumes maximum of 14 channels
+  int pwm_outputs_[14]; //assumes maximum of 14 channels
 
   // Time variables
   gazebo::common::Time boot_time_;
   uint64_t next_imu_update_time_us_;
   uint64_t imu_update_period_us_;
 
-  void RCCallback(const rosflight_msgs::RCRaw& msg);
+  void RCCallback(const rosflight_msgs::RCRaw &msg);
   bool motors_spinning();
 
   GazeboVector prev_vel_1_;
@@ -149,24 +150,24 @@ public:
   uint16_t num_sensor_errors(void) override;
 
   bool new_imu_data() override;
-  bool imu_read(float accel[3], float* temperature, float gyro[3], uint64_t* time_us) override;
+  bool imu_read(float accel[3], float *temperature, float gyro[3], uint64_t *time_us) override;
   void imu_not_responding_error() override;
 
   bool mag_present(void) override;
   void mag_read(float mag[3]) override;
-  void mag_update(void) override {};
+  void mag_update(void) override{};
 
   bool baro_present(void) override;
   void baro_read(float *pressure, float *temperature) override;
-  void baro_update(void) override {};
+  void baro_update(void) override{};
 
   bool diff_pressure_present(void) override;
   void diff_pressure_read(float *diff_pressure, float *temperature) override;
-  void diff_pressure_update(void) override {};
+  void diff_pressure_update(void) override{};
 
   bool sonar_present(void) override;
   float sonar_read(void) override;
-  void sonar_update(void) override {};
+  void sonar_update(void) override{};
 
   // PWM
   // TODO make these deal in normalized (-1 to 1 or 0 to 1) values (not pwm-specific)
@@ -179,11 +180,10 @@ public:
   void rc_init(rc_type_t rc_type) override;
   bool rc_lost(void) override;
 
-
   // non-volatile memory
   void memory_init(void) override;
-  bool memory_read(void * dest, size_t len) override;
-  bool memory_write(const void * src, size_t len) override;
+  bool memory_read(void *dest, size_t len) override;
+  bool memory_write(const void *src, size_t len) override;
 
   // LEDs
   void led0_on(void) override;
@@ -216,13 +216,12 @@ public:
   void battery_current_set_multiplier(double multiplier) override;
 
   // Gazebo stuff
-  void gazebo_setup(gazebo::physics::LinkPtr link, gazebo::physics::WorldPtr world, gazebo::physics::ModelPtr model, ros::NodeHandle* nh, std::string mav_type);
-  inline const int* get_outputs() const { return pwm_outputs_; }
+  void gazebo_setup(gazebo::physics::LinkPtr link, gazebo::physics::WorldPtr world, gazebo::physics::ModelPtr model, ros::NodeHandle *nh, std::string mav_type);
+  inline const int *get_outputs() const { return pwm_outputs_; }
 #if GAZEBO_MAJOR_VERSION >= 9
   gazebo::common::SphericalCoordinates sph_coord_;
 #endif
-
-  };
+};
 
 } // namespace rosflight_sim
 

--- a/rosflight_sim/include/rosflight_sim/sil_board.h
+++ b/rosflight_sim/include/rosflight_sim/sil_board.h
@@ -110,6 +110,7 @@ private:
   ros::Subscriber rc_sub_;
   rosflight_msgs::RCRaw latestRC_;
   ros::Time last_rc_message_timestamp_;
+  static constexpr float RC_TIMEOUT_PERIOD_S{1.0};
   bool rc_received_;
 
   std::string mav_type_;

--- a/rosflight_sim/src/sil_board.cpp
+++ b/rosflight_sim/src/sil_board.cpp
@@ -467,7 +467,7 @@ void SIL_Board::pwm_disable()
 
 bool SIL_Board::rc_lost(void)
 {
-  if ((ros::Time::now() - last_rc_message_timestamp_).toSec() > 1)
+  if ((ros::Time::now() - last_rc_message_timestamp_).toSec() > RC_TIMEOUT_PERIOD_S)
   {
     ROS_INFO_THROTTLE(20, "RC timeout");
     return true;

--- a/rosflight_sim/src/sil_board.cpp
+++ b/rosflight_sim/src/sil_board.cpp
@@ -444,7 +444,7 @@ void SIL_Board::pwm_init(uint32_t refresh_rate, uint16_t idle_pwm)
 
 float SIL_Board::rc_read(uint8_t channel)
 {
-  if(rc_sub_.getNumPublishers() > 0)
+  if (rc_received_)
   {
     return static_cast<float>(latestRC_.values[channel]-1000)/1000.0;
   }
@@ -468,7 +468,12 @@ void SIL_Board::pwm_disable()
 
 bool SIL_Board::rc_lost(void)
 {
-  return !rc_received_;
+  if ((ros::Time::now() - last_rc_message_).toSec() > 1)
+  {
+    ROS_INFO_THROTTLE(20, "RC timeout");
+    return true;
+  }
+  return !rc_received_ || ((ros::Time::now() - last_rc_message_).toSec() > 1);
 }
 
 void SIL_Board::rc_init(rc_type_t rc_type) {}

--- a/rosflight_sim/src/sil_board.cpp
+++ b/rosflight_sim/src/sil_board.cpp
@@ -38,9 +38,9 @@
 namespace rosflight_sim
 {
 
-SIL_Board::SIL_Board() :
-    rosflight_firmware::UDPBoard()
-{}
+SIL_Board::SIL_Board() : rosflight_firmware::UDPBoard()
+{
+}
 
 void SIL_Board::init_board(void)
 {
@@ -49,11 +49,11 @@ void SIL_Board::init_board(void)
 
 constexpr double rad2Deg(double x)
 {
-  return 180.0/M_PI * x;
+  return 180.0 / M_PI * x;
 }
 constexpr double deg2Rad(double x)
 {
-  return M_PI/180.0 * x;
+  return M_PI / 180.0 * x;
 }
 
 void SIL_Board::gazebo_setup(gazebo::physics::LinkPtr link, gazebo::physics::WorldPtr world,
@@ -64,7 +64,6 @@ void SIL_Board::gazebo_setup(gazebo::physics::LinkPtr link, gazebo::physics::Wor
   model_ = model;
   nh_ = nh;
   mav_type_ = mav_type;
-
 
   std::string bind_host = nh->param<std::string>("gazebo_host", "localhost");
   int bind_port = nh->param<int>("gazebo_port", 14525);
@@ -100,14 +99,14 @@ void SIL_Board::gazebo_setup(gazebo::physics::LinkPtr link, gazebo::physics::Wor
   sonar_max_range_ = nh_->param<double>("sonar_max_range", 8.0);
 
   imu_update_rate_ = nh_->param<double>("imu_update_rate", 1000.0);
-  imu_update_period_us_ = (uint64_t)(1e6/imu_update_rate_);
+  imu_update_period_us_ = (uint64_t)(1e6 / imu_update_rate_);
 
   // Calculate Magnetic Field Vector (for mag simulation)
   double inclination = nh_->param<double>("inclination", 1.14316156541);
   double declination = nh_->param<double>("declination", 0.198584539676);
   GZ_COMPAT_SET_Z(inertial_magnetic_field_, sin(-inclination));
-  GZ_COMPAT_SET_X(inertial_magnetic_field_, cos(-inclination)*cos(-declination));
-  GZ_COMPAT_SET_Y(inertial_magnetic_field_, cos(-inclination)*sin(-declination));
+  GZ_COMPAT_SET_X(inertial_magnetic_field_, cos(-inclination) * cos(-declination));
+  GZ_COMPAT_SET_Y(inertial_magnetic_field_, cos(-inclination) * sin(-declination));
 
   // Get the desired altitude at the ground (for baro and LLA)
 
@@ -120,24 +119,24 @@ void SIL_Board::gazebo_setup(gazebo::physics::LinkPtr link, gazebo::physics::Wor
   gps_velocity_stdev_ = nh->param<double>("gps_velocity_stdev", 0.1);
 
   // Configure Noise
-  random_generator_= std::default_random_engine(std::chrono::system_clock::now().time_since_epoch().count());
+  random_generator_ = std::default_random_engine(std::chrono::system_clock::now().time_since_epoch().count());
   normal_distribution_ = std::normal_distribution<double>(0.0, 1.0);
   uniform_distribution_ = std::uniform_real_distribution<double>(-1.0, 1.0);
 
   gravity_ = GZ_COMPAT_GET_GRAVITY(world_);
 
   // Initialize the Sensor Biases
-  GZ_COMPAT_SET_X(gyro_bias_, gyro_bias_range_*uniform_distribution_(random_generator_));
-  GZ_COMPAT_SET_Y(gyro_bias_, gyro_bias_range_*uniform_distribution_(random_generator_));
-  GZ_COMPAT_SET_Z(gyro_bias_, gyro_bias_range_*uniform_distribution_(random_generator_));
-  GZ_COMPAT_SET_X(acc_bias_, acc_bias_range_*uniform_distribution_(random_generator_));
-  GZ_COMPAT_SET_Y(acc_bias_, acc_bias_range_*uniform_distribution_(random_generator_));
-  GZ_COMPAT_SET_Z(acc_bias_, acc_bias_range_*uniform_distribution_(random_generator_));
-  GZ_COMPAT_SET_X(mag_bias_, mag_bias_range_*uniform_distribution_(random_generator_));
-  GZ_COMPAT_SET_Y(mag_bias_, mag_bias_range_*uniform_distribution_(random_generator_));
-  GZ_COMPAT_SET_Z(mag_bias_, mag_bias_range_*uniform_distribution_(random_generator_));
-  baro_bias_ = baro_bias_range_*uniform_distribution_(random_generator_);
-  airspeed_bias_ = airspeed_bias_range_*uniform_distribution_(random_generator_);
+  GZ_COMPAT_SET_X(gyro_bias_, gyro_bias_range_ * uniform_distribution_(random_generator_));
+  GZ_COMPAT_SET_Y(gyro_bias_, gyro_bias_range_ * uniform_distribution_(random_generator_));
+  GZ_COMPAT_SET_Z(gyro_bias_, gyro_bias_range_ * uniform_distribution_(random_generator_));
+  GZ_COMPAT_SET_X(acc_bias_, acc_bias_range_ * uniform_distribution_(random_generator_));
+  GZ_COMPAT_SET_Y(acc_bias_, acc_bias_range_ * uniform_distribution_(random_generator_));
+  GZ_COMPAT_SET_Z(acc_bias_, acc_bias_range_ * uniform_distribution_(random_generator_));
+  GZ_COMPAT_SET_X(mag_bias_, mag_bias_range_ * uniform_distribution_(random_generator_));
+  GZ_COMPAT_SET_Y(mag_bias_, mag_bias_range_ * uniform_distribution_(random_generator_));
+  GZ_COMPAT_SET_Z(mag_bias_, mag_bias_range_ * uniform_distribution_(random_generator_));
+  baro_bias_ = baro_bias_range_ * uniform_distribution_(random_generator_);
+  airspeed_bias_ = airspeed_bias_range_ * uniform_distribution_(random_generator_);
 
   prev_vel_1_ = GZ_COMPAT_GET_RELATIVE_LINEAR_VEL(link_);
   prev_vel_2_ = GZ_COMPAT_GET_RELATIVE_LINEAR_VEL(link_);
@@ -154,13 +153,13 @@ void SIL_Board::board_reset(bool bootloader)
 
 uint32_t SIL_Board::clock_millis()
 {
-  uint32_t millis =  (uint32_t)((GZ_COMPAT_GET_SIM_TIME(world_) - boot_time_).Double()*1e3);
+  uint32_t millis = (uint32_t)((GZ_COMPAT_GET_SIM_TIME(world_) - boot_time_).Double() * 1e3);
   return millis;
 }
 
 uint64_t SIL_Board::clock_micros()
 {
-  uint64_t micros = (uint64_t)((GZ_COMPAT_GET_SIM_TIME(world_) - boot_time_).Double()*1e6);
+  uint64_t micros = (uint64_t)((GZ_COMPAT_GET_SIM_TIME(world_) - boot_time_).Double() * 1e6);
   return micros;
 }
 
@@ -174,19 +173,19 @@ void SIL_Board::clock_delay(uint32_t milliseconds)
 void SIL_Board::sensors_init()
 {
   // Initialize the Biases
-  GZ_COMPAT_SET_X(gyro_bias_, gyro_bias_range_*uniform_distribution_(random_generator_));
-  GZ_COMPAT_SET_Y(gyro_bias_, gyro_bias_range_*uniform_distribution_(random_generator_));
-  GZ_COMPAT_SET_Z(gyro_bias_, gyro_bias_range_*uniform_distribution_(random_generator_));
-  GZ_COMPAT_SET_X(acc_bias_, acc_bias_range_*uniform_distribution_(random_generator_));
-  GZ_COMPAT_SET_Y(acc_bias_, acc_bias_range_*uniform_distribution_(random_generator_));
-  GZ_COMPAT_SET_Z(acc_bias_, acc_bias_range_*uniform_distribution_(random_generator_));
+  GZ_COMPAT_SET_X(gyro_bias_, gyro_bias_range_ * uniform_distribution_(random_generator_));
+  GZ_COMPAT_SET_Y(gyro_bias_, gyro_bias_range_ * uniform_distribution_(random_generator_));
+  GZ_COMPAT_SET_Z(gyro_bias_, gyro_bias_range_ * uniform_distribution_(random_generator_));
+  GZ_COMPAT_SET_X(acc_bias_, acc_bias_range_ * uniform_distribution_(random_generator_));
+  GZ_COMPAT_SET_Y(acc_bias_, acc_bias_range_ * uniform_distribution_(random_generator_));
+  GZ_COMPAT_SET_Z(acc_bias_, acc_bias_range_ * uniform_distribution_(random_generator_));
 
   // Gazebo coordinates is NWU and Earth's magnetic field is defined in NED, hence the negative signs
   double inclination_ = 1.14316156541;
   double declination_ = 0.198584539676;
   GZ_COMPAT_SET_Z(inertial_magnetic_field_, sin(-inclination_));
-  GZ_COMPAT_SET_X(inertial_magnetic_field_, cos(-inclination_)*cos(-declination_));
-  GZ_COMPAT_SET_Y(inertial_magnetic_field_, cos(-inclination_)*sin(-declination_));
+  GZ_COMPAT_SET_X(inertial_magnetic_field_, cos(-inclination_) * cos(-declination_));
+  GZ_COMPAT_SET_Y(inertial_magnetic_field_, cos(-inclination_) * sin(-declination_));
 
 #if GAZEBO_MAJOR_VERSION >= 9
   using SC = gazebo::common::SphericalCoordinates;
@@ -196,7 +195,7 @@ void SIL_Board::sensors_init()
   sph_coord_.SetLongitudeReference(Ang(deg2Rad(origin_longitude_)));
   sph_coord_.SetElevationReference(origin_altitude_);
   // Force x-axis to be north-aligned. I promise, I will change everything to ENU in the next commit
-  sph_coord_.SetHeadingOffset(Ang(-M_PI/2.0));
+  sph_coord_.SetHeadingOffset(Ang(-M_PI / 2.0));
 #endif
 }
 
@@ -219,7 +218,7 @@ bool SIL_Board::new_imu_data()
   }
 }
 
-bool SIL_Board::imu_read(float accel[3], float* temperature, float gyro[3], uint64_t* time_us)
+bool SIL_Board::imu_read(float accel[3], float *temperature, float gyro[3], uint64_t *time_us)
 {
   GazeboQuaternion q_I_NWU = GZ_COMPAT_GET_ROT(GZ_COMPAT_GET_WORLD_POSE(link_));
   GazeboVector current_vel = GZ_COMPAT_GET_RELATIVE_LINEAR_VEL(link_);
@@ -234,15 +233,15 @@ bool SIL_Board::imu_read(float accel[3], float* temperature, float gyro[3], uint
   // Apply normal noise (only if armed, because most of the noise comes from motors
   if (motors_spinning())
   {
-    GZ_COMPAT_SET_X(y_acc, GZ_COMPAT_GET_X(y_acc) + acc_stdev_*normal_distribution_(random_generator_));
-    GZ_COMPAT_SET_Y(y_acc, GZ_COMPAT_GET_Y(y_acc) + acc_stdev_*normal_distribution_(random_generator_));
-    GZ_COMPAT_SET_Z(y_acc, GZ_COMPAT_GET_Z(y_acc) + acc_stdev_*normal_distribution_(random_generator_));
+    GZ_COMPAT_SET_X(y_acc, GZ_COMPAT_GET_X(y_acc) + acc_stdev_ * normal_distribution_(random_generator_));
+    GZ_COMPAT_SET_Y(y_acc, GZ_COMPAT_GET_Y(y_acc) + acc_stdev_ * normal_distribution_(random_generator_));
+    GZ_COMPAT_SET_Z(y_acc, GZ_COMPAT_GET_Z(y_acc) + acc_stdev_ * normal_distribution_(random_generator_));
   }
 
   // Perform Random Walk for biases
-  GZ_COMPAT_SET_X(acc_bias_, GZ_COMPAT_GET_X(acc_bias_) + acc_bias_walk_stdev_*normal_distribution_(random_generator_));
-  GZ_COMPAT_SET_Y(acc_bias_, GZ_COMPAT_GET_Y(acc_bias_) + acc_bias_walk_stdev_*normal_distribution_(random_generator_));
-  GZ_COMPAT_SET_Z(acc_bias_, GZ_COMPAT_GET_Z(acc_bias_) + acc_bias_walk_stdev_*normal_distribution_(random_generator_));
+  GZ_COMPAT_SET_X(acc_bias_, GZ_COMPAT_GET_X(acc_bias_) + acc_bias_walk_stdev_ * normal_distribution_(random_generator_));
+  GZ_COMPAT_SET_Y(acc_bias_, GZ_COMPAT_GET_Y(acc_bias_) + acc_bias_walk_stdev_ * normal_distribution_(random_generator_));
+  GZ_COMPAT_SET_Z(acc_bias_, GZ_COMPAT_GET_Z(acc_bias_) + acc_bias_walk_stdev_ * normal_distribution_(random_generator_));
 
   // Add constant Bias to measurement
   GZ_COMPAT_SET_X(y_acc, GZ_COMPAT_GET_X(y_acc) + GZ_COMPAT_GET_X(acc_bias_));
@@ -259,15 +258,15 @@ bool SIL_Board::imu_read(float accel[3], float* temperature, float gyro[3], uint
   // Normal Noise from motors
   if (motors_spinning())
   {
-    GZ_COMPAT_SET_X(y_gyro, GZ_COMPAT_GET_X(y_gyro) + gyro_stdev_*normal_distribution_(random_generator_));
-    GZ_COMPAT_SET_Y(y_gyro, GZ_COMPAT_GET_Y(y_gyro) + gyro_stdev_*normal_distribution_(random_generator_));
-    GZ_COMPAT_SET_Z(y_gyro, GZ_COMPAT_GET_Z(y_gyro) + gyro_stdev_*normal_distribution_(random_generator_));
+    GZ_COMPAT_SET_X(y_gyro, GZ_COMPAT_GET_X(y_gyro) + gyro_stdev_ * normal_distribution_(random_generator_));
+    GZ_COMPAT_SET_Y(y_gyro, GZ_COMPAT_GET_Y(y_gyro) + gyro_stdev_ * normal_distribution_(random_generator_));
+    GZ_COMPAT_SET_Z(y_gyro, GZ_COMPAT_GET_Z(y_gyro) + gyro_stdev_ * normal_distribution_(random_generator_));
   }
 
   // Random Walk for bias
-  GZ_COMPAT_SET_X(gyro_bias_, GZ_COMPAT_GET_X(gyro_bias_) + gyro_bias_walk_stdev_*normal_distribution_(random_generator_));
-  GZ_COMPAT_SET_Y(gyro_bias_, GZ_COMPAT_GET_Y(gyro_bias_) + gyro_bias_walk_stdev_*normal_distribution_(random_generator_));
-  GZ_COMPAT_SET_Z(gyro_bias_, GZ_COMPAT_GET_Z(gyro_bias_) + gyro_bias_walk_stdev_*normal_distribution_(random_generator_));
+  GZ_COMPAT_SET_X(gyro_bias_, GZ_COMPAT_GET_X(gyro_bias_) + gyro_bias_walk_stdev_ * normal_distribution_(random_generator_));
+  GZ_COMPAT_SET_Y(gyro_bias_, GZ_COMPAT_GET_Y(gyro_bias_) + gyro_bias_walk_stdev_ * normal_distribution_(random_generator_));
+  GZ_COMPAT_SET_Z(gyro_bias_, GZ_COMPAT_GET_Z(gyro_bias_) + gyro_bias_walk_stdev_ * normal_distribution_(random_generator_));
 
   // Apply Constant Bias
   GZ_COMPAT_SET_X(y_gyro, GZ_COMPAT_GET_X(y_gyro) + GZ_COMPAT_GET_X(gyro_bias_));
@@ -293,14 +292,14 @@ void SIL_Board::mag_read(float mag[3])
 {
   GazeboPose I_to_B = GZ_COMPAT_GET_WORLD_POSE(link_);
   GazeboVector noise;
-  GZ_COMPAT_SET_X(noise, mag_stdev_*normal_distribution_(random_generator_));
-  GZ_COMPAT_SET_Y(noise, mag_stdev_*normal_distribution_(random_generator_));
-  GZ_COMPAT_SET_Z(noise, mag_stdev_*normal_distribution_(random_generator_));
+  GZ_COMPAT_SET_X(noise, mag_stdev_ * normal_distribution_(random_generator_));
+  GZ_COMPAT_SET_Y(noise, mag_stdev_ * normal_distribution_(random_generator_));
+  GZ_COMPAT_SET_Z(noise, mag_stdev_ * normal_distribution_(random_generator_));
 
   // Random Walk for bias
-  GZ_COMPAT_SET_X(mag_bias_, GZ_COMPAT_GET_X(mag_bias_) + mag_bias_walk_stdev_*normal_distribution_(random_generator_));
-  GZ_COMPAT_SET_Y(mag_bias_, GZ_COMPAT_GET_Y(mag_bias_) + mag_bias_walk_stdev_*normal_distribution_(random_generator_));
-  GZ_COMPAT_SET_Z(mag_bias_, GZ_COMPAT_GET_Z(mag_bias_) + mag_bias_walk_stdev_*normal_distribution_(random_generator_));
+  GZ_COMPAT_SET_X(mag_bias_, GZ_COMPAT_GET_X(mag_bias_) + mag_bias_walk_stdev_ * normal_distribution_(random_generator_));
+  GZ_COMPAT_SET_Y(mag_bias_, GZ_COMPAT_GET_Y(mag_bias_) + mag_bias_walk_stdev_ * normal_distribution_(random_generator_));
+  GZ_COMPAT_SET_Z(mag_bias_, GZ_COMPAT_GET_Z(mag_bias_) + mag_bias_walk_stdev_ * normal_distribution_(random_generator_));
 
   // combine parts to create a measurement
   GazeboVector y_mag = GZ_COMPAT_GET_ROT(I_to_B).RotateVectorReverse(inertial_magnetic_field_) + mag_bias_ + noise;
@@ -330,13 +329,13 @@ void SIL_Board::baro_read(float *pressure, float *temperature)
   double alt = GZ_COMPAT_GET_Z(GZ_COMPAT_GET_POS(current_state_NWU)) + origin_altitude_;
 
   // Convert to the true pressure reading
-  double y_baro = 101325.0f*(float)pow((1-2.25694e-5 * alt), 5.2553);
+  double y_baro = 101325.0f * (float)pow((1 - 2.25694e-5 * alt), 5.2553);
 
   // Add noise
-  y_baro += baro_stdev_*normal_distribution_(random_generator_);
+  y_baro += baro_stdev_ * normal_distribution_(random_generator_);
 
   // Perform random walk
-  baro_bias_ += baro_bias_walk_stdev_*normal_distribution_(random_generator_);
+  baro_bias_ += baro_bias_walk_stdev_ * normal_distribution_(random_generator_);
 
   // Add random walk
   y_baro += baro_bias_;
@@ -347,7 +346,7 @@ void SIL_Board::baro_read(float *pressure, float *temperature)
 
 bool SIL_Board::diff_pressure_present(void)
 {
-  if(mav_type_ == "fixedwing")
+  if (mav_type_ == "fixedwing")
     return true;
   else
     return false;
@@ -362,11 +361,11 @@ void SIL_Board::diff_pressure_read(float *diff_pressure, float *temperature)
   double Va = GZ_COMPAT_GET_LENGTH(vel);
 
   // Invert Airpseed to get sensor measurement
-  double y_as = rho_*Va*Va/2.0; // Page 130 in the UAV Book
+  double y_as = rho_ * Va * Va / 2.0; // Page 130 in the UAV Book
 
   // Add noise
-  y_as += airspeed_stdev_*normal_distribution_(random_generator_);
-  airspeed_bias_ += airspeed_bias_walk_stdev_*normal_distribution_(random_generator_);
+  y_as += airspeed_stdev_ * normal_distribution_(random_generator_);
+  airspeed_bias_ += airspeed_bias_walk_stdev_ * normal_distribution_(random_generator_);
   y_as += airspeed_bias_;
 
   *diff_pressure = y_as;
@@ -392,7 +391,7 @@ float SIL_Board::sonar_read(void)
     return sonar_max_range_;
   }
   else
-    return alt + sonar_stdev_*normal_distribution_(random_generator_);
+    return alt + sonar_stdev_ * normal_distribution_(random_generator_);
 }
 
 bool SIL_Board::battery_voltage_present() const
@@ -446,11 +445,11 @@ float SIL_Board::rc_read(uint8_t channel)
 {
   if (rc_received_)
   {
-    return static_cast<float>(latestRC_.values[channel]-1000)/1000.0;
+    return static_cast<float>(latestRC_.values[channel] - 1000) / 1000.0;
   }
 
   //no publishers, set throttle low and center everything else
-  if(channel == 2)
+  if (channel == 2)
     return 0.0;
 
   return 0.5;
@@ -458,22 +457,22 @@ float SIL_Board::rc_read(uint8_t channel)
 
 void SIL_Board::pwm_write(uint8_t channel, float value)
 {
-  pwm_outputs_[channel] = 1000+(uint16_t)(1000*value);
+  pwm_outputs_[channel] = 1000 + (uint16_t)(1000 * value);
 }
 void SIL_Board::pwm_disable()
 {
-  for(int i=0;i<14;i++)
-	  pwm_write(i,0);
+  for (int i = 0; i < 14; i++)
+    pwm_write(i, 0);
 }
 
 bool SIL_Board::rc_lost(void)
 {
-  if ((ros::Time::now() - last_rc_message_).toSec() > 1)
+  if ((ros::Time::now() - last_rc_message_timestamp_).toSec() > 1)
   {
     ROS_INFO_THROTTLE(20, "RC timeout");
     return true;
   }
-  return !rc_received_ || ((ros::Time::now() - last_rc_message_).toSec() > 1);
+  return !rc_received_ || ((ros::Time::now() - last_rc_message_timestamp_).toSec() > 1);
 }
 
 void SIL_Board::rc_init(rc_type_t rc_type) {}
@@ -481,24 +480,24 @@ void SIL_Board::rc_init(rc_type_t rc_type) {}
 // non-volatile memory
 void SIL_Board::memory_init(void) {}
 
-bool SIL_Board::memory_read(void * dest, size_t len)
+bool SIL_Board::memory_read(void *dest, size_t len)
 {
   std::string directory = "rosflight_memory" + nh_->getNamespace();
   std::ifstream memory_file;
   memory_file.open(directory + "/mem.bin", std::ios::binary);
 
-  if(!memory_file.is_open())
+  if (!memory_file.is_open())
   {
     ROS_ERROR("Unable to load rosflight memory file %s/mem.bin", directory.c_str());
     return false;
   }
 
-  memory_file.read((char*) dest, len);
+  memory_file.read((char *)dest, len);
   memory_file.close();
   return true;
 }
 
-bool SIL_Board::memory_write(const void * src, size_t len)
+bool SIL_Board::memory_write(const void *src, size_t len)
 {
   std::string directory = "rosflight_memory" + nh_->getNamespace();
   std::string mkdir_command = "mkdir -p " + directory;
@@ -512,28 +511,28 @@ bool SIL_Board::memory_write(const void * src, size_t len)
 
   std::ofstream memory_file;
   memory_file.open(directory + "/mem.bin", std::ios::binary);
-  memory_file.write((char*) src, len);
+  memory_file.write((char *)src, len);
   memory_file.close();
   return true;
 }
 
 bool SIL_Board::motors_spinning()
 {
-  if(pwm_outputs_[2] > 1100)
-      return true;
+  if (pwm_outputs_[2] > 1100)
+    return true;
   else
     return false;
 }
 
 // LED
 
-void SIL_Board::led0_on(void) { }
-void SIL_Board::led0_off(void) { }
-void SIL_Board::led0_toggle(void) { }
+void SIL_Board::led0_on(void) {}
+void SIL_Board::led0_off(void) {}
+void SIL_Board::led0_toggle(void) {}
 
-void SIL_Board::led1_on(void) { }
-void SIL_Board::led1_off(void) { }
-void SIL_Board::led1_toggle(void) { }
+void SIL_Board::led1_on(void) {}
+void SIL_Board::led1_off(void) {}
+void SIL_Board::led1_toggle(void) {}
 
 void SIL_Board::backup_memory_init()
 {
@@ -541,7 +540,7 @@ void SIL_Board::backup_memory_init()
 
 bool SIL_Board::backup_memory_read(void *dest, size_t len)
 {
-  if(len <= BACKUP_SRAM_SIZE)
+  if (len <= BACKUP_SRAM_SIZE)
   {
     memcpy(dest, backup_memory_, len);
     return true;
@@ -558,14 +557,15 @@ void SIL_Board::backup_memory_write(const void *src, size_t len)
 
 void SIL_Board::backup_memory_clear(size_t len)
 {
-  if(len< BACKUP_SRAM_SIZE)
+  if (len < BACKUP_SRAM_SIZE)
     memset(backup_memory_, 0, len);
 }
 
-void SIL_Board::RCCallback(const rosflight_msgs::RCRaw& msg)
+void SIL_Board::RCCallback(const rosflight_msgs::RCRaw &msg)
 {
   rc_received_ = true;
   latestRC_ = msg;
+  last_rc_message_timestamp_ = ros::Time::now();
 }
 
 bool SIL_Board::gnss_present() { return GAZEBO_MAJOR_VERSION >= 9; }
@@ -615,7 +615,7 @@ rosflight_firmware::GNSSData SIL_Board::gnss_read()
   out.ecef.x = std::round(ecef_pos.X() * 100);
   out.ecef.y = std::round(ecef_pos.Y() * 100);
   out.ecef.z = std::round(ecef_pos.Z() * 100);
-  out.ecef.p_acc = std::round(out.h_acc/10.0);
+  out.ecef.p_acc = std::round(out.h_acc / 10.0);
   out.ecef.vx = std::round(ecef_vel.X() * 100);
   out.ecef.vy = std::round(ecef_vel.Y() * 100);
   out.ecef.vz = std::round(ecef_vel.Z() * 100);
@@ -624,7 +624,7 @@ rosflight_firmware::GNSSData SIL_Board::gnss_read()
   out.rosflight_timestamp = clock_micros();
 
 #endif
-      return out;
+  return out;
 }
 
 bool SIL_Board::gnss_has_new_data() { return GAZEBO_MAJOR_VERSION >= 9; }
@@ -685,18 +685,16 @@ rosflight_firmware::GNSSRaw SIL_Board::gnss_raw_read()
   // Again, TODO switch to using ENU convention per REP
   double vn = local_vel.X();
   double ve = -local_vel.Y();
-  double ground_speed = std::sqrt(vn*vn + ve*ve);
+  double ground_speed = std::sqrt(vn * vn + ve * ve);
   out.g_speed = std::round(ground_speed * 1000);
 
   double head_mot = std::atan2(ve, vn);
-  out.head_mot = std::round(rad2Deg(head_mot)*1e5);
+  out.head_mot = std::round(rad2Deg(head_mot) * 1e5);
   out.p_dop = 0.0; // TODO
   out.rosflight_timestamp = clock_micros();
 
 #endif
   return out;
 }
-
-
 
 } // namespace rosflight_sim


### PR DESCRIPTION
This changes the RC failsafe behavior when using the SIL simulation. In the old behavior, RC is never considered lost, once at least one message has been sent to the RC input. If there are no active publishers, the RC values default to centered sticks, zero throttle, and switches off. If using an arm switch, this disarms the aircraft, which also disables the failsafe behavior.

This PR changes the behavior. Now, if no RC messages are received for 1 second, the board starts acknowledging that RC is lost. Additionally, calls to `rc_read` return the most recent RC value instead of centering. This allows for better testing of failsafe behavior in simulation.