### PR TITLE
Mavrosflight logger abstraction

### DIFF
--- a/rosflight/CMakeLists.txt
+++ b/rosflight/CMakeLists.txt
@@ -75,6 +75,7 @@ add_library(mavrosflight
   src/mavrosflight/time_manager.cpp
 )
 add_dependencies(mavrosflight ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_compile_definitions(mavrosflight PRIVATE USE_ROS)
 target_link_libraries(mavrosflight
   ${catkin_LIBRARIES}
   ${Boost_LIBRARIES}

--- a/rosflight/include/rosflight/logger_ros.h
+++ b/rosflight/include/rosflight/logger_ros.h
@@ -56,19 +56,19 @@ class LoggerROS : public LoggerInterface
 {
 public:
   inline void debug(const std::string &message) override { ROS_DEBUG("[mavrosflight]: %s", message.c_str()); }
-  inline void debug_throttle(float rate, const std::string &message) override { ROS_DEBUG_THROTTLE(rate, "[mavrosflight]: %s", message.c_str()); }
+  inline void debug_throttle(float period, const std::string &message) override { ROS_DEBUG_THROTTLE(period, "[mavrosflight]: %s", message.c_str()); }
 
   inline void info(const std::string &message) override { ROS_INFO("[mavrosflight]: %s", message.c_str()); }
-  inline void info_throttle(float rate, const std::string &message) override { ROS_INFO_THROTTLE(rate, "[mavrosflight]: %s", message.c_str()); }
+  inline void info_throttle(float period, const std::string &message) override { ROS_INFO_THROTTLE(period, "[mavrosflight]: %s", message.c_str()); }
 
   inline void warn(const std::string &message) override { ROS_WARN("[mavrosflight]: %s", message.c_str()); }
-  inline void warn_throttle(float rate, const std::string &message) override { ROS_WARN_THROTTLE(rate, "[mavrosflight]: %s", message.c_str()); }
+  inline void warn_throttle(float period, const std::string &message) override { ROS_WARN_THROTTLE(period, "[mavrosflight]: %s", message.c_str()); }
 
   inline void error(const std::string &message) override { ROS_ERROR("[mavrosflight]: %s", message.c_str()); }
-  inline void error_throttle(float rate, const std::string &message) override { ROS_ERROR_THROTTLE(rate, "[mavrosflight]: %s", message.c_str()); }
+  inline void error_throttle(float period, const std::string &message) override { ROS_ERROR_THROTTLE(period, "[mavrosflight]: %s", message.c_str()); }
 
   inline void fatal(const std::string &message) override { ROS_FATAL("[mavrosflight]: %s", message.c_str()); }
-  inline void fatal_throttle(float rate, const std::string &message) override { ROS_FATAL_THROTTLE(rate, "[mavrosflight]: %s", message.c_str()); }
+  inline void fatal_throttle(float period, const std::string &message) override { ROS_FATAL_THROTTLE(period, "[mavrosflight]: %s", message.c_str()); }
 };
 
 } // namespace rosflight

--- a/rosflight/include/rosflight/logger_ros.h
+++ b/rosflight/include/rosflight/logger_ros.h
@@ -52,23 +52,33 @@ namespace rosflight
  * This is a convenience logger implementation for ROS-based projects.
  * The implementation simply forwards messages to the appropriate rosconsole loggers.
  */
-class LoggerROS : public mavrosflight::LoggerInterface
+class LoggerROS : public mavrosflight::LoggerInterface<LoggerROS>
 {
 public:
-  inline void debug(const std::string &message) override { ROS_DEBUG("[mavrosflight]: %s", message.c_str()); }
-  inline void debug_throttle(float period, const std::string &message) override { ROS_DEBUG_THROTTLE(period, "[mavrosflight]: %s", message.c_str()); }
+  template <typename... T>
+  inline void debug(const std::string &format.c_str(), const T&... args) { ROS_DEBUG(format.c_str(), args...); }
+  template <typename... T>
+  inline void debug_throttle(float period, const std::string &format.c_str(), const T&... args) { ROS_DEBUG_THROTTLE(period, format.c_str(), args...); }
 
-  inline void info(const std::string &message) override { ROS_INFO("[mavrosflight]: %s", message.c_str()); }
-  inline void info_throttle(float period, const std::string &message) override { ROS_INFO_THROTTLE(period, "[mavrosflight]: %s", message.c_str()); }
+  template <typename... T>
+  inline void info(const std::string &format.c_str(), const T&... args) { ROS_INFO(format.c_str(), args...); }
+  template <typename... T>
+  inline void info_throttle(float period, const std::string &format.c_str(), const T&... args) { ROS_INFO_THROTTLE(period, format.c_str(), args...); }
 
-  inline void warn(const std::string &message) override { ROS_WARN("[mavrosflight]: %s", message.c_str()); }
-  inline void warn_throttle(float period, const std::string &message) override { ROS_WARN_THROTTLE(period, "[mavrosflight]: %s", message.c_str()); }
+  template <typename... T>
+  inline void warn(const std::string &format.c_str(), const T&... args) { ROS_WARN(format.c_str(), args...); }
+  template <typename... T>
+  inline void warn_throttle(float period, const std::string &format.c_str(), const T&... args) { ROS_WARN_THROTTLE(period, format.c_str(), args...); }
 
-  inline void error(const std::string &message) override { ROS_ERROR("[mavrosflight]: %s", message.c_str()); }
-  inline void error_throttle(float period, const std::string &message) override { ROS_ERROR_THROTTLE(period, "[mavrosflight]: %s", message.c_str()); }
+  template <typename... T>
+  inline void error(const std::string &format.c_str(), const T&... args) { ROS_ERROR(format.c_str(), args...); }
+  template <typename... T>
+  inline void error_throttle(float period, const std::string &format.c_str(), const T&... args) { ROS_ERROR_THROTTLE(period, format.c_str(), args...); }
 
-  inline void fatal(const std::string &message) override { ROS_FATAL("[mavrosflight]: %s", message.c_str()); }
-  inline void fatal_throttle(float period, const std::string &message) override { ROS_FATAL_THROTTLE(period, "[mavrosflight]: %s", message.c_str()); }
+  template <typename... T>
+  inline void fatal(const std::string &format.c_str(), const T&... args) { ROS_FATAL(format.c_str(), args...); }
+  template <typename... T>
+  inline void fatal_throttle(float period, const std::string &format.c_str(), const T&... args) { ROS_FATAL_THROTTLE(period, format.c_str(), args...); }
 };
 
 } // namespace rosflight

--- a/rosflight/include/rosflight/logger_ros.h
+++ b/rosflight/include/rosflight/logger_ros.h
@@ -56,29 +56,29 @@ class LoggerROS : public mavrosflight::LoggerInterface<LoggerROS>
 {
 public:
   template <typename... T>
-  inline void debug(const std::string &format.c_str(), const T&... args) { ROS_DEBUG(format.c_str(), args...); }
+  inline void debug(const std::string &format, const T&... args) { ROS_DEBUG(format.c_str(), args...); }
   template <typename... T>
-  inline void debug_throttle(float period, const std::string &format.c_str(), const T&... args) { ROS_DEBUG_THROTTLE(period, format.c_str(), args...); }
+  inline void debug_throttle(float period, const std::string &format, const T&... args) { ROS_DEBUG_THROTTLE(period, format.c_str(), args...); }
 
   template <typename... T>
-  inline void info(const std::string &format.c_str(), const T&... args) { ROS_INFO(format.c_str(), args...); }
+  inline void info(const std::string &format, const T&... args) { ROS_INFO(format.c_str(), args...); }
   template <typename... T>
-  inline void info_throttle(float period, const std::string &format.c_str(), const T&... args) { ROS_INFO_THROTTLE(period, format.c_str(), args...); }
+  inline void info_throttle(float period, const std::string &format, const T&... args) { ROS_INFO_THROTTLE(period, format.c_str(), args...); }
 
   template <typename... T>
-  inline void warn(const std::string &format.c_str(), const T&... args) { ROS_WARN(format.c_str(), args...); }
+  inline void warn(const std::string &format, const T&... args) { ROS_WARN(format.c_str(), args...); }
   template <typename... T>
-  inline void warn_throttle(float period, const std::string &format.c_str(), const T&... args) { ROS_WARN_THROTTLE(period, format.c_str(), args...); }
+  inline void warn_throttle(float period, const std::string &format, const T&... args) { ROS_WARN_THROTTLE(period, format.c_str(), args...); }
 
   template <typename... T>
-  inline void error(const std::string &format.c_str(), const T&... args) { ROS_ERROR(format.c_str(), args...); }
+  inline void error(const std::string &format, const T&... args) { ROS_ERROR(format.c_str(), args...); }
   template <typename... T>
-  inline void error_throttle(float period, const std::string &format.c_str(), const T&... args) { ROS_ERROR_THROTTLE(period, format.c_str(), args...); }
+  inline void error_throttle(float period, const std::string &format, const T&... args) { ROS_ERROR_THROTTLE(period, format.c_str(), args...); }
 
   template <typename... T>
-  inline void fatal(const std::string &format.c_str(), const T&... args) { ROS_FATAL(format.c_str(), args...); }
+  inline void fatal(const std::string &format, const T&... args) { ROS_FATAL(format.c_str(), args...); }
   template <typename... T>
-  inline void fatal_throttle(float period, const std::string &format.c_str(), const T&... args) { ROS_FATAL_THROTTLE(period, format.c_str(), args...); }
+  inline void fatal_throttle(float period, const std::string &format, const T&... args) { ROS_FATAL_THROTTLE(period, format.c_str(), args...); }
 };
 
 } // namespace rosflight

--- a/rosflight/include/rosflight/logger_ros.h
+++ b/rosflight/include/rosflight/logger_ros.h
@@ -56,10 +56,19 @@ class LoggerROS : public LoggerInterface
 {
 public:
   inline void debug(const std::string &message) override { ROS_DEBUG("[mavrosflight]: %s", message.c_str()); }
-  inline void  info(const std::string &message) override { ROS_INFO("[mavrosflight]: %s", message.c_str()); }
-  inline void  warn(const std::string &message) override { ROS_WARN("[mavrosflight]: %s", message.c_str()); }
+  inline void debug_throttle(float rate, const std::string &message) override { ROS_DEBUG_THROTTLE(rate, "[mavrosflight]: %s", message.c_str()); }
+
+  inline void info(const std::string &message) override { ROS_INFO("[mavrosflight]: %s", message.c_str()); }
+  inline void info_throttle(float rate, const std::string &message) override { ROS_INFO_THROTTLE(rate, "[mavrosflight]: %s", message.c_str()); }
+
+  inline void warn(const std::string &message) override { ROS_WARN("[mavrosflight]: %s", message.c_str()); }
+  inline void warn_throttle(float rate, const std::string &message) override { ROS_WARN_THROTTLE(rate, "[mavrosflight]: %s", message.c_str()); }
+
   inline void error(const std::string &message) override { ROS_ERROR("[mavrosflight]: %s", message.c_str()); }
+  inline void error_throttle(float rate, const std::string &message) override { ROS_ERROR_THROTTLE(rate, "[mavrosflight]: %s", message.c_str()); }
+
   inline void fatal(const std::string &message) override { ROS_FATAL("[mavrosflight]: %s", message.c_str()); }
+  inline void fatal_throttle(float rate, const std::string &message) override { ROS_FATAL_THROTTLE(rate, "[mavrosflight]: %s", message.c_str()); }
 };
 
 } // namespace rosflight

--- a/rosflight/include/rosflight/logger_ros.h
+++ b/rosflight/include/rosflight/logger_ros.h
@@ -1,0 +1,67 @@
+/*
+ * Software License Agreement (BSD-3 License)
+ *
+ * Copyright (c) 2018 Daniel Koch.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file logger_ros.h
+ * @author Daniel Koch <danielpkoch@gmail.com>
+ */
+
+#ifndef ROSFLIGHT_LOGGER_ROS_H
+#define ROSFLIGHT_LOGGER_ROS_H
+
+#include <rosflight/mavrosflight/logger_interface.h>
+
+#include <ros/ros.h>
+
+namespace rosflight
+{
+
+/**
+ * @class LoggerROS
+ * @brief Logger implementation for ROS environments
+ *
+ * This is a convenience logger implementation for ROS-based projects.
+ * The implementation simply forwards messages to the appropriate rosconsole loggers.
+ */
+class LoggerROS : public LoggerInterface
+{
+public:
+  inline void debug(const std::string &message) override { ROS_DEBUG("[mavrosflight]: %s", message.c_str()); }
+  inline void  info(const std::string &message) override { ROS_INFO("[mavrosflight]: %s", message.c_str()); }
+  inline void  warn(const std::string &message) override { ROS_WARN("[mavrosflight]: %s", message.c_str()); }
+  inline void error(const std::string &message) override { ROS_ERROR("[mavrosflight]: %s", message.c_str()); }
+  inline void fatal(const std::string &message) override { ROS_FATAL("[mavrosflight]: %s", message.c_str()); }
+};
+
+} // namespace rosflight
+
+#endif // ROSFLIGHT_LOGGER_ROS_H

--- a/rosflight/include/rosflight/logger_ros.h
+++ b/rosflight/include/rosflight/logger_ros.h
@@ -52,7 +52,7 @@ namespace rosflight
  * This is a convenience logger implementation for ROS-based projects.
  * The implementation simply forwards messages to the appropriate rosconsole loggers.
  */
-class LoggerROS : public LoggerInterface
+class LoggerROS : public mavrosflight::LoggerInterface
 {
 public:
   inline void debug(const std::string &message) override { ROS_DEBUG("[mavrosflight]: %s", message.c_str()); }

--- a/rosflight/include/rosflight/mavrosflight/default_logger.h
+++ b/rosflight/include/rosflight/mavrosflight/default_logger.h
@@ -53,64 +53,64 @@ namespace mavrosflight
 class DefaultLogger : public LoggerInterface<DefaultLogger>
 {
 public:
-  template <typename... T>
-  inline void debug(const char* format, const T&... args)
+  template <typename... Args>
+  inline void debug(const char* format, const Args&... args)
   {
     _log(stdout, "DEBUG", format, args...);
   }
-  template <typename... T>
-  inline void debug_throttle(float period, const char* format, const T&... args)
+  template <typename... Args>
+  inline void debug_throttle(float period, const char* format, const Args&... args)
   {
     debug(format, args...);
   }
 
-  template <typename... T>
-  inline void info(const char* format, const T&... args)
+  template <typename... Args>
+  inline void info(const char* format, const Args&... args)
   {
     _log(stdout, "INFO", format, args...);
   }
-  template <typename... T>
-  inline void info_throttle(float period, const char* format, const T&... args)
+  template <typename... Args>
+  inline void info_throttle(float period, const char* format, const Args&... args)
   {
     info(format, args...);
   }
 
-  template <typename... T>
-  inline void warn(const char* format, const T&... args)
+  template <typename... Args>
+  inline void warn(const char* format, const Args&... args)
   {
     _log(stderr, "WARN", format, args...);
   }
-  template <typename... T>
-  inline void warn_throttle(float period, const char* format, const T&... args)
+  template <typename... Args>
+  inline void warn_throttle(float period, const char* format, const Args&... args)
   {
     warn(format, args...);
   }
 
-  template <typename... T>
-  inline void error(const char* format, const T&... args)
+  template <typename... Args>
+  inline void error(const char* format, const Args&... args)
   {
     _log(stderr, "ERROR", format, args...);
   }
-  template <typename... T>
-  inline void error_throttle(float period, const char* format, const T&... args)
+  template <typename... Args>
+  inline void error_throttle(float period, const char* format, const Args&... args)
   {
     error(format, args...);
   }
 
-  template <typename... T>
-  inline void fatal(const char* format, const T&... args)
+  template <typename... Args>
+  inline void fatal(const char* format, const Args&... args)
   {
     _log(stderr, "FATAL", format, args...);
   }
-  template <typename... T>
-  inline void fatal_throttle(float period, const char* format, const T&... args)
+  template <typename... Args>
+  inline void fatal_throttle(float period, const char* format, const Args&... args)
   {
     fatal(format, args...);
   }
 
 private:
-  template <typename... T>
-  inline void _log(FILE* fs, const char* name, const char* format, const T&... args)
+  template <typename... Args>
+  inline void _log(FILE* fs, const char* name, const char* format, const Args&... args)
   {
     std::stringstream ss;
     ss << "[mavrosflight][" << name << "]: " << format << std::endl;

--- a/rosflight/include/rosflight/mavrosflight/default_logger.h
+++ b/rosflight/include/rosflight/mavrosflight/default_logger.h
@@ -35,88 +35,92 @@
  * @author Jacob Willis <jbwillis272@gmail.com>
  */
 
-#ifndef MAVROSFLIGHT_LOGGER_INTERFACE_H
-#define MAVROSFLIGHT_LOGGER_INTERFACE_H
+#ifndef MAVROSFLIGHT_DEFAULT_LOGGER_H
+#define MAVROSFLIGHT_DEFAULT_LOGGER_H
+
+#include <cstdio>
+#include <sstream>
+
+#include <rosflight/mavrosflight/logger_interface.h>
 
 namespace mavrosflight
 {
 /**
- * \class LoggerInterface
- * \brief Abstract base class for message handler
- *
- * The implementations of this class define how messages are displayed, logged,
- * etc. To create custom behavior, a derived class should implement each of the
- * public functions.
+ * \class DefaultLogger
+ * \brief Default logger that outputs to stdout and stderr. Throttling
+ *  is ignored to reduce timing complexity.
  */
-template <typename Derived>
-class LoggerInterface
+class DefaultLogger : public LoggerInterface<DefaultLogger>
 {
 public:
   template <typename... T>
-  void debug(const char* format, const T&... args)
+  inline void debug(const char* format, const T&... args)
   {
-    Derived& derived = static_cast<Derived&>(*this);
-    derived.debug(format, args...);
+    _log(stdout, "DEBUG", format, args...);
   }
   template <typename... T>
-  void debug_throttle(float period, const char* format, const T&... args)
+  inline void debug_throttle(float period, const char* format, const T&... args)
   {
-    Derived& derived = static_cast<Derived&>(*this);
-    derived.debug_throttle(period, format, args...);
+    debug(format, args...);
   }
 
   template <typename... T>
-  void info(const char* format, const T&... args)
+  inline void info(const char* format, const T&... args)
   {
-    Derived& derived = static_cast<Derived&>(*this);
-    derived.info(format, args...);
+    _log(stdout, "INFO", format, args...);
   }
   template <typename... T>
-  void info_throttle(float period, const char* format, const T&... args)
+  inline void info_throttle(float period, const char* format, const T&... args)
   {
-    Derived& derived = static_cast<Derived&>(*this);
-    derived.info_throttle(period, format, args...);
+    info(format, args...);
   }
 
   template <typename... T>
-  void warn(const char* format, const T&... args)
+  inline void warn(const char* format, const T&... args)
   {
-    Derived& derived = static_cast<Derived&>(*this);
-    derived.warn(format, args...);
+    _log(stderr, "WARN", format, args...);
   }
   template <typename... T>
-  void warn_throttle(float period, const char* format, const T&... args)
+  inline void warn_throttle(float period, const char* format, const T&... args)
   {
-    Derived& derived = static_cast<Derived&>(*this);
-    derived.warn_throttle(period, format, args...);
+    warn(format, args...);
   }
 
   template <typename... T>
-  void error(const char* format, const T&... args)
+  inline void error(const char* format, const T&... args)
   {
-    Derived& derived = static_cast<Derived&>(*this);
-    derived.error(format, args...);
+    _log(stderr, "ERROR", format, args...);
   }
   template <typename... T>
-  void error_throttle(float period, const char* format, const T&... args)
+  inline void error_throttle(float period, const char* format, const T&... args)
   {
-    Derived& derived = static_cast<Derived&>(*this);
-    derived.error_throttle(period, format, args...);
+    error(format, args...);
   }
 
   template <typename... T>
-  void fatal(const char* format, const T&... args)
+  inline void fatal(const char* format, const T&... args)
   {
-    Derived& derived = static_cast<Derived&>(*this);
-    derived.fatal(format, args...);
+    _log(stderr, "FATAL", format, args...);
   }
   template <typename... T>
-  void fatal_throttle(float period, const char* format, const T&... args)
+  inline void fatal_throttle(float period, const char* format, const T&... args)
   {
-    Derived& derived = static_cast<Derived&>(*this);
-    derived.fatal_throttle(period, format, args...);
+    fatal(format, args...);
+  }
+
+private:
+  template <typename... T>
+  inline void _log(FILE* fs, const char* name, const char* format, const T&... args)
+  {
+    std::stringstream ss;
+    ss << "[mavrosflight][" << name << "]: " << format << std::endl;
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
+    fprintf(fs, ss.str().c_str(), args...);
+#pragma GCC diagnostic pop
   }
 };
 
 } // namespace mavrosflight
-#endif // MAVROSFLIGHT_LOGGER_INTERFACE_H
+#endif // MAVROSFLIGHT_DEFAULT_LOGGER_H

--- a/rosflight/include/rosflight/mavrosflight/logger_adapter.h
+++ b/rosflight/include/rosflight/mavrosflight/logger_adapter.h
@@ -1,0 +1,57 @@
+/*
+ * Software License Agreement (BSD-3 License)
+ *
+ * Copyright (c) 2020 Jacob Willis.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file logger_interface.h
+ * @author Jacob Willis <jbwillis272@gmail.com>
+ */
+
+#ifndef MAVROSFLIGHT_LOGGER_ADAPTER_H
+#define MAVROSFLIGHT_LOGGER_ADAPTER_H
+
+#if defined(USE_ROS)
+#include <rosflight/ros_logger.h>
+namespace mavrosflight
+{
+using DerivedLoggerType = rosflight::ROSLogger;
+}
+#elif defined(STANDALONE)
+#include <rosflight/mavrosflight/default_logger.h>
+namespace mavrosflight
+{
+using DerivedLoggerType = mavrosflight::DefaultLogger;
+}
+#else
+#error "Unknown logging backend supplied for mavrosflight. Define USE_ROS or STANDALONE."
+#endif
+
+#endif // MAVROSFLIGHT_LOGGER_ADAPTER_H

--- a/rosflight/include/rosflight/mavrosflight/logger_interface.h
+++ b/rosflight/include/rosflight/mavrosflight/logger_interface.h
@@ -191,10 +191,10 @@ private:
     std::stringstream ss;
     ss << "[mavrosflight][" << name << "]: " << format << std::endl;
 
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wformat-security"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
     fprintf(fs, ss.str().c_str(), args...);
-    #pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
   }
 };
 } // namespace mavrosflight

--- a/rosflight/include/rosflight/mavrosflight/logger_interface.h
+++ b/rosflight/include/rosflight/mavrosflight/logger_interface.h
@@ -190,7 +190,11 @@ private:
   {
     std::stringstream ss;
     ss << "[mavrosflight][" << name << "]: " << format << std::endl;
+
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wformat-security"
     fprintf(fs, ss.str().c_str(), args...);
+    #pragma GCC diagnostic pop
   }
 };
 } // namespace mavrosflight

--- a/rosflight/include/rosflight/mavrosflight/logger_interface.h
+++ b/rosflight/include/rosflight/mavrosflight/logger_interface.h
@@ -38,8 +38,10 @@
 #ifndef MAVROSFLIGHT_LOGGER_INTERFACE_H
 #define MAVROSFLIGHT_LOGGER_INTERFACE_H
 
-#include <iostream>
+#include <sstream>
 #include <string>
+
+#include <stdio.h>
 
 namespace mavrosflight
 {
@@ -55,20 +57,30 @@ namespace mavrosflight
 class LoggerInterface
 {
 public:
-  virtual void debug(const std::string& message) = 0;
-  virtual void debug_throttle(float period, const std::string& message) = 0;
+  template <typename... T>
+  virtual void debug(const std::string& format, T... args) = 0;
+  template <typename... T>
+  virtual void debug_throttle(float period, const std::string& format, T... args) = 0;
 
-  virtual void info(const std::string& message) = 0;
-  virtual void info_throttle(float period, const std::string& message) = 0;
+  template <typename... T>
+  virtual void info(const std::string& format, T... args) = 0;
+  template <typename... T>
+  virtual void info_throttle(float period, const std::string& format, T... args) = 0;
 
-  virtual void warn(const std::string& message) = 0;
-  virtual void warn_throttle(float period, const std::string& message) = 0;
+  template <typename... T>
+  virtual void warn(const std::string& format, T... args) = 0;
+  template <typename... T>
+  virtual void warn_throttle(float period, const std::string& format, T... args) = 0;
 
-  virtual void error(const std::string& message) = 0;
-  virtual void error_throttle(float period, const std::string& message) = 0;
+  template <typename... T>
+  virtual void error(const std::string& format, T... args) = 0;
+  template <typename... T>
+  virtual void error_throttle(float period, const std::string& format, T... args) = 0;
 
-  virtual void fatal(const std::string& message) = 0;
-  virtual void fatal_throttle(float period, const std::string& message) = 0;
+  template <typename... T>
+  virtual void fatal(const std::string& format, T... args) = 0;
+  template <typename... T>
+  virtual void fatal_throttle(float period, const std::string& format, T... args) = 0;
 };
 
 /**
@@ -78,21 +90,30 @@ public:
 class DefaultLogger : public LoggerInterface
 {
 public:
-  inline void debug(const std::string &message) override { std::cout << "[mavrosflight][DEBUG]: " << message << std::endl; }
-  inline void debug_throttle(float period, const std::string &message) override { debug(message); }
+  inline void debug(const std::string &format, T... args) override {_log(stdout, "DEBUG", format, args...);}
+  inline void debug_throttle(float period, const std::string &format, T... args) override { debug(format); }
 
-  inline void info(const std::string &message) override { std::cout << "[mavrosflight][INFO]: " << message << std::endl; }
-  inline void info_throttle(float period, const std::string &message) override { info(message); }
+  inline void info(const std::string &format, T... args) override {_log(stdout, "INFO", format, args...);}
+  inline void info_throttle(float period, const std::string &format, T... args) override { info(format); }
 
-  inline void warn(const std::string &message) override { std::cerr << "[mavrosflight][WARN]: " << message << std::endl; }
-  inline void warn_throttle(float period, const std::string &message) override { warn(message); }
+  inline void warn(const std::string &format, T... args) override {_log(stderr, "WARN", format, args...);}
+  inline void warn_throttle(float period, const std::string &format, T... args) override { warn(format); }
 
-  inline void error(const std::string &message) override { std::cerr << "[mavrosflight][ERROR]: " << message << std::endl; }
-  inline void error_throttle(float period, const std::string &message) override { error(message); }
+  inline void error(const std::string &format, T... args) override {_log(stderr, "ERROR", format, args...);}
+  inline void error_throttle(float period, const std::string &format, T... args) override { error(format); }
 
-  inline void fatal(const std::string &message) override { std::cerr << "[mavrosflight][FATAL]: " << message << std::endl; }
-  inline void fatal_throttle(float period, const std::string &message) override { fatal(message); }
+  inline void fatal(const std::string &format, T... args) override {_log(stderr, "FATAL", format, args...);}
+  inline void fatal_throttle(float period, const std::string &format, T... args) override { fatal(format); }
 };
+
+private:
+  template <typename ... T>
+  inline void _log(FILE *fs, const std::string &name, const std::string &format, T... args)
+  {
+    std::stringstream ss;
+    ss << "[mavrosflight][" << name << "]: " << format << std::endl;
+    fprintf(fs, ss.str().c_str(), args);
+  }
 
 } // namespace mavrosflight
 

--- a/rosflight/include/rosflight/mavrosflight/logger_interface.h
+++ b/rosflight/include/rosflight/mavrosflight/logger_interface.h
@@ -155,7 +155,6 @@ public:
   inline void fatal(const std::string &format, const T&... args) {_log(stderr, "FATAL", format, args...);}
   template <typename... T>
   inline void fatal_throttle(float period, const std::string &format, const T&... args) { fatal(format); }
-};
 
 private:
   template <typename ... T>
@@ -163,9 +162,10 @@ private:
   {
     std::stringstream ss;
     ss << "[mavrosflight][" << name << "]: " << format << std::endl;
-    fprintf(fs, ss.str().c_str(), args);
+    fprintf(fs, ss.str().c_str(), args...);
   }
 
+};
 } // namespace mavrosflight
 
 #endif // MAVROSFLIGHT_LOGGER_INTERFACE_H

--- a/rosflight/include/rosflight/mavrosflight/logger_interface.h
+++ b/rosflight/include/rosflight/mavrosflight/logger_interface.h
@@ -51,59 +51,100 @@ namespace mavrosflight
  * \brief Abstract base class for message handler
  *
  * The implementations of this class define how messages are displayed, logged,
- * etc. To create custom behavior, derive from this base class and override the
- * pure virtual functions.
+ * etc. To create custom behavior, a derived class should implement each of the
+ * public functions.
  */
+template <typename Derived>
 class LoggerInterface
 {
 public:
   template <typename... T>
-  virtual void debug(const std::string& format, T... args) = 0;
+  void debug(const std::string& format, T... args)
+  {
+    Derived& derived = static_cast<Derived&>(*this);
+    derived.debug(format, args...);
+  }
   template <typename... T>
-  virtual void debug_throttle(float period, const std::string& format, T... args) = 0;
+  void debug_throttle(float period, const std::string& format, T... args)
+  {
+    Derived& derived = static_cast<Derived&>(*this);
+    derived.debug_throttle(format, args...);
+  }
 
   template <typename... T>
-  virtual void info(const std::string& format, T... args) = 0;
+  void info(const std::string& format, T... args)
+  {
+    Derived& derived = static_cast<Derived&>(*this);
+    derived.info(format, args...);
+  }
   template <typename... T>
-  virtual void info_throttle(float period, const std::string& format, T... args) = 0;
+  void info_throttle(float period, const std::string& format, T... args)
+  {
+    Derived& derived = static_cast<Derived&>(*this);
+    derived.info_throttle(format, args...);
+  }
 
   template <typename... T>
-  virtual void warn(const std::string& format, T... args) = 0;
+  void warn(const std::string& format, T... args)
+  {
+    Derived& derived = static_cast<Derived&>(*this);
+    derived.warn(format, args...);
+  }
   template <typename... T>
-  virtual void warn_throttle(float period, const std::string& format, T... args) = 0;
+  void warn_throttle(float period, const std::string& format, T... args)
+  {
+    Derived& derived = static_cast<Derived&>(*this);
+    derived.warn_throttle(format, args...);
+  }
 
   template <typename... T>
-  virtual void error(const std::string& format, T... args) = 0;
+  void error(const std::string& format, T... args)
+  {
+    Derived& derived = static_cast<Derived&>(*this);
+    derived.error(format, args...);
+  }
   template <typename... T>
-  virtual void error_throttle(float period, const std::string& format, T... args) = 0;
+  void error_throttle(float period, const std::string& format, T... args)
+  {
+    Derived& derived = static_cast<Derived&>(*this);
+    derived.error_throttle(format, args...);
+  }
 
   template <typename... T>
-  virtual void fatal(const std::string& format, T... args) = 0;
+  void fatal(const std::string& format, T... args)
+  {
+    Derived& derived = static_cast<Derived&>(*this);
+    derived.fatal(format, args...);
+  }
   template <typename... T>
-  virtual void fatal_throttle(float period, const std::string& format, T... args) = 0;
+  void fatal_throttle(float period, const std::string& format, T... args)
+  {
+    Derived& derived = static_cast<Derived&>(*this);
+    derived.fatal_throttle(format, args...);
+  }
 };
 
 /**
  * \class DefaultLogger
  * \brief Default logger that outputs to stdout and stderr
  */
-class DefaultLogger : public LoggerInterface
+class DefaultLogger : public LoggerInterface<DefaultLogger>
 {
 public:
-  inline void debug(const std::string &format, T... args) override {_log(stdout, "DEBUG", format, args...);}
-  inline void debug_throttle(float period, const std::string &format, T... args) override { debug(format); }
+  inline void debug(const std::string &format, T... args) {_log(stdout, "DEBUG", format, args...);}
+  inline void debug_throttle(float period, const std::string &format, T... args) { debug(format); }
 
-  inline void info(const std::string &format, T... args) override {_log(stdout, "INFO", format, args...);}
-  inline void info_throttle(float period, const std::string &format, T... args) override { info(format); }
+  inline void info(const std::string &format, T... args) {_log(stdout, "INFO", format, args...);}
+  inline void info_throttle(float period, const std::string &format, T... args) { info(format); }
 
-  inline void warn(const std::string &format, T... args) override {_log(stderr, "WARN", format, args...);}
-  inline void warn_throttle(float period, const std::string &format, T... args) override { warn(format); }
+  inline void warn(const std::string &format, T... args) {_log(stderr, "WARN", format, args...);}
+  inline void warn_throttle(float period, const std::string &format, T... args) { warn(format); }
 
-  inline void error(const std::string &format, T... args) override {_log(stderr, "ERROR", format, args...);}
-  inline void error_throttle(float period, const std::string &format, T... args) override { error(format); }
+  inline void error(const std::string &format, T... args) {_log(stderr, "ERROR", format, args...);}
+  inline void error_throttle(float period, const std::string &format, T... args) { error(format); }
 
-  inline void fatal(const std::string &format, T... args) override {_log(stderr, "FATAL", format, args...);}
-  inline void fatal_throttle(float period, const std::string &format, T... args) override { fatal(format); }
+  inline void fatal(const std::string &format, T... args) {_log(stderr, "FATAL", format, args...);}
+  inline void fatal_throttle(float period, const std::string &format, T... args) { fatal(format); }
 };
 
 private:

--- a/rosflight/include/rosflight/mavrosflight/logger_interface.h
+++ b/rosflight/include/rosflight/mavrosflight/logger_interface.h
@@ -138,7 +138,7 @@ public:
   template <typename... T>
   inline void debug_throttle(float period, const std::string& format, const T&... args)
   {
-    debug(format);
+    debug(format, args...);
   }
 
   template <typename... T>
@@ -149,7 +149,7 @@ public:
   template <typename... T>
   inline void info_throttle(float period, const std::string& format, const T&... args)
   {
-    info(format);
+    info(format, args...);
   }
 
   template <typename... T>
@@ -160,7 +160,7 @@ public:
   template <typename... T>
   inline void warn_throttle(float period, const std::string& format, const T&... args)
   {
-    warn(format);
+    warn(format, args...);
   }
 
   template <typename... T>
@@ -171,7 +171,7 @@ public:
   template <typename... T>
   inline void error_throttle(float period, const std::string& format, const T&... args)
   {
-    error(format);
+    error(format, args...);
   }
 
   template <typename... T>
@@ -182,7 +182,7 @@ public:
   template <typename... T>
   inline void fatal_throttle(float period, const std::string& format, const T&... args)
   {
-    fatal(format);
+    fatal(format, args...);
   }
 
 private:

--- a/rosflight/include/rosflight/mavrosflight/logger_interface.h
+++ b/rosflight/include/rosflight/mavrosflight/logger_interface.h
@@ -56,19 +56,19 @@ class LoggerInterface
 {
 public:
   virtual void debug(const std::string& message) = 0;
-  virtual void debug_throttle(float rate, const std::string& message) = 0;
+  virtual void debug_throttle(float period, const std::string& message) = 0;
 
   virtual void info(const std::string& message) = 0;
-  virtual void info_throttle(float rate, const std::string& message) = 0;
+  virtual void info_throttle(float period, const std::string& message) = 0;
 
   virtual void warn(const std::string& message) = 0;
-  virtual void warn_throttle(float rate, const std::string& message) = 0;
+  virtual void warn_throttle(float period, const std::string& message) = 0;
 
   virtual void error(const std::string& message) = 0;
-  virtual void error_throttle(float rate, const std::string& message) = 0;
+  virtual void error_throttle(float period, const std::string& message) = 0;
 
   virtual void fatal(const std::string& message) = 0;
-  virtual void fatal_throttle(float rate, const std::string& message) = 0;
+  virtual void fatal_throttle(float period, const std::string& message) = 0;
 };
 
 /**
@@ -79,19 +79,19 @@ class DefaultLogger : public LoggerInterface
 {
 public:
   inline void debug(const std::string &message) override { std::cout << "[mavrosflight][DEBUG]: " << message << std::endl; }
-  inline void debug_throttle(float rate, const std::string &message) override { debug(message); }
+  inline void debug_throttle(float period, const std::string &message) override { debug(message); }
 
   inline void info(const std::string &message) override { std::cout << "[mavrosflight][INFO]: " << message << std::endl; }
-  inline void info_throttle(float rate, const std::string &message) override { info(message); }
+  inline void info_throttle(float period, const std::string &message) override { info(message); }
 
   inline void warn(const std::string &message) override { std::cerr << "[mavrosflight][WARN]: " << message << std::endl; }
-  inline void warn_throttle(float rate, const std::string &message) override { warn(message); }
+  inline void warn_throttle(float period, const std::string &message) override { warn(message); }
 
   inline void error(const std::string &message) override { std::cerr << "[mavrosflight][ERROR]: " << message << std::endl; }
-  inline void error_throttle(float rate, const std::string &message) override { error(message); }
+  inline void error_throttle(float period, const std::string &message) override { error(message); }
 
   inline void fatal(const std::string &message) override { std::cerr << "[mavrosflight][FATAL]: " << message << std::endl; }
-  inline void fatal_throttle(float rate, const std::string &message) override { fatal(message); }
+  inline void fatal_throttle(float period, const std::string &message) override { fatal(message); }
 };
 
 } // namespace mavrosflight

--- a/rosflight/include/rosflight/mavrosflight/logger_interface.h
+++ b/rosflight/include/rosflight/mavrosflight/logger_interface.h
@@ -52,66 +52,66 @@ template <typename Derived>
 class LoggerInterface
 {
 public:
-  template <typename... T>
-  void debug(const char* format, const T&... args)
+  template <typename... Args>
+  void debug(const char* format, const Args&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.debug(format, args...);
   }
-  template <typename... T>
-  void debug_throttle(float period, const char* format, const T&... args)
+  template <typename... Args>
+  void debug_throttle(float period, const char* format, const Args&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.debug_throttle(period, format, args...);
   }
 
-  template <typename... T>
-  void info(const char* format, const T&... args)
+  template <typename... Args>
+  void info(const char* format, const Args&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.info(format, args...);
   }
-  template <typename... T>
-  void info_throttle(float period, const char* format, const T&... args)
+  template <typename... Args>
+  void info_throttle(float period, const char* format, const Args&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.info_throttle(period, format, args...);
   }
 
-  template <typename... T>
-  void warn(const char* format, const T&... args)
+  template <typename... Args>
+  void warn(const char* format, const Args&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.warn(format, args...);
   }
-  template <typename... T>
-  void warn_throttle(float period, const char* format, const T&... args)
+  template <typename... Args>
+  void warn_throttle(float period, const char* format, const Args&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.warn_throttle(period, format, args...);
   }
 
-  template <typename... T>
-  void error(const char* format, const T&... args)
+  template <typename... Args>
+  void error(const char* format, const Args&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.error(format, args...);
   }
-  template <typename... T>
-  void error_throttle(float period, const char* format, const T&... args)
+  template <typename... Args>
+  void error_throttle(float period, const char* format, const Args&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.error_throttle(period, format, args...);
   }
 
-  template <typename... T>
-  void fatal(const char* format, const T&... args)
+  template <typename... Args>
+  void fatal(const char* format, const Args&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.fatal(format, args...);
   }
-  template <typename... T>
-  void fatal_throttle(float period, const char* format, const T&... args)
+  template <typename... Args>
+  void fatal_throttle(float period, const char* format, const Args&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.fatal_throttle(period, format, args...);

--- a/rosflight/include/rosflight/mavrosflight/logger_interface.h
+++ b/rosflight/include/rosflight/mavrosflight/logger_interface.h
@@ -39,7 +39,6 @@
 #define MAVROSFLIGHT_LOGGER_INTERFACE_H
 
 #include <sstream>
-#include <string>
 
 #include <stdio.h>
 
@@ -58,65 +57,65 @@ class LoggerInterface
 {
 public:
   template <typename... T>
-  void debug(const std::string& format, const T&... args)
+  void debug(const char* format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.debug(format, args...);
   }
   template <typename... T>
-  void debug_throttle(float period, const std::string& format, const T&... args)
+  void debug_throttle(float period, const char* format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.debug_throttle(period, format, args...);
   }
 
   template <typename... T>
-  void info(const std::string& format, const T&... args)
+  void info(const char* format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.info(format, args...);
   }
   template <typename... T>
-  void info_throttle(float period, const std::string& format, const T&... args)
+  void info_throttle(float period, const char* format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.info_throttle(period, format, args...);
   }
 
   template <typename... T>
-  void warn(const std::string& format, const T&... args)
+  void warn(const char* format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.warn(format, args...);
   }
   template <typename... T>
-  void warn_throttle(float period, const std::string& format, const T&... args)
+  void warn_throttle(float period, const char* format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.warn_throttle(period, format, args...);
   }
 
   template <typename... T>
-  void error(const std::string& format, const T&... args)
+  void error(const char* format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.error(format, args...);
   }
   template <typename... T>
-  void error_throttle(float period, const std::string& format, const T&... args)
+  void error_throttle(float period, const char* format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.error_throttle(period, format, args...);
   }
 
   template <typename... T>
-  void fatal(const std::string& format, const T&... args)
+  void fatal(const char* format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.fatal(format, args...);
   }
   template <typename... T>
-  void fatal_throttle(float period, const std::string& format, const T&... args)
+  void fatal_throttle(float period, const char* format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.fatal_throttle(period, format, args...);
@@ -131,63 +130,63 @@ class DefaultLogger : public LoggerInterface<DefaultLogger>
 {
 public:
   template <typename... T>
-  inline void debug(const std::string& format, const T&... args)
+  inline void debug(const char* format, const T&... args)
   {
     _log(stdout, "DEBUG", format, args...);
   }
   template <typename... T>
-  inline void debug_throttle(float period, const std::string& format, const T&... args)
+  inline void debug_throttle(float period, const char* format, const T&... args)
   {
     debug(format, args...);
   }
 
   template <typename... T>
-  inline void info(const std::string& format, const T&... args)
+  inline void info(const char* format, const T&... args)
   {
     _log(stdout, "INFO", format, args...);
   }
   template <typename... T>
-  inline void info_throttle(float period, const std::string& format, const T&... args)
+  inline void info_throttle(float period, const char* format, const T&... args)
   {
     info(format, args...);
   }
 
   template <typename... T>
-  inline void warn(const std::string& format, const T&... args)
+  inline void warn(const char* format, const T&... args)
   {
     _log(stderr, "WARN", format, args...);
   }
   template <typename... T>
-  inline void warn_throttle(float period, const std::string& format, const T&... args)
+  inline void warn_throttle(float period, const char* format, const T&... args)
   {
     warn(format, args...);
   }
 
   template <typename... T>
-  inline void error(const std::string& format, const T&... args)
+  inline void error(const char* format, const T&... args)
   {
     _log(stderr, "ERROR", format, args...);
   }
   template <typename... T>
-  inline void error_throttle(float period, const std::string& format, const T&... args)
+  inline void error_throttle(float period, const char* format, const T&... args)
   {
     error(format, args...);
   }
 
   template <typename... T>
-  inline void fatal(const std::string& format, const T&... args)
+  inline void fatal(const char* format, const T&... args)
   {
     _log(stderr, "FATAL", format, args...);
   }
   template <typename... T>
-  inline void fatal_throttle(float period, const std::string& format, const T&... args)
+  inline void fatal_throttle(float period, const char* format, const T&... args)
   {
     fatal(format, args...);
   }
 
 private:
   template <typename... T>
-  inline void _log(FILE* fs, const std::string& name, const std::string& format, const T&... args)
+  inline void _log(FILE* fs, const char* name, const char* format, const T&... args)
   {
     std::stringstream ss;
     ss << "[mavrosflight][" << name << "]: " << format << std::endl;

--- a/rosflight/include/rosflight/mavrosflight/logger_interface.h
+++ b/rosflight/include/rosflight/mavrosflight/logger_interface.h
@@ -1,7 +1,7 @@
 /*
  * Software License Agreement (BSD-3 License)
  *
- * Copyright (c) 2018 Daniel Koch.
+ * Copyright (c) 2020 Jacob Willis.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,7 +32,7 @@
 
 /**
  * @file logger_interface.h
- * @author Daniel Koch <danielpkoch@gmail.com>
+ * @author Jacob Willis <jbwillis272@gmail.com>
  */
 
 #ifndef MAVROSFLIGHT_LOGGER_INTERFACE_H

--- a/rosflight/include/rosflight/mavrosflight/logger_interface.h
+++ b/rosflight/include/rosflight/mavrosflight/logger_interface.h
@@ -56,10 +56,19 @@ class LoggerInterface
 {
 public:
   virtual void debug(const std::string& message) = 0;
-  virtual void  info(const std::string& message) = 0;
-  virtual void  warn(const std::string& message) = 0;
+  virtual void debug_throttle(float rate, const std::string& message) = 0;
+
+  virtual void info(const std::string& message) = 0;
+  virtual void info_throttle(float rate, const std::string& message) = 0;
+
+  virtual void warn(const std::string& message) = 0;
+  virtual void warn_throttle(float rate, const std::string& message) = 0;
+
   virtual void error(const std::string& message) = 0;
+  virtual void error_throttle(float rate, const std::string& message) = 0;
+
   virtual void fatal(const std::string& message) = 0;
+  virtual void fatal_throttle(float rate, const std::string& message) = 0;
 };
 
 /**

--- a/rosflight/include/rosflight/mavrosflight/logger_interface.h
+++ b/rosflight/include/rosflight/mavrosflight/logger_interface.h
@@ -45,7 +45,6 @@
 
 namespace mavrosflight
 {
-
 /**
  * \class LoggerInterface
  * \brief Abstract base class for message handler
@@ -132,39 +131,68 @@ class DefaultLogger : public LoggerInterface<DefaultLogger>
 {
 public:
   template <typename... T>
-  inline void debug(const std::string &format, const T&... args) {_log(stdout, "DEBUG", format, args...);}
+  inline void debug(const std::string& format, const T&... args)
+  {
+    _log(stdout, "DEBUG", format, args...);
+  }
   template <typename... T>
-  inline void debug_throttle(float period, const std::string &format, const T&... args) { debug(format); }
+  inline void debug_throttle(float period, const std::string& format, const T&... args)
+  {
+    debug(format);
+  }
 
   template <typename... T>
-  inline void info(const std::string &format, const T&... args) {_log(stdout, "INFO", format, args...);}
+  inline void info(const std::string& format, const T&... args)
+  {
+    _log(stdout, "INFO", format, args...);
+  }
   template <typename... T>
-  inline void info_throttle(float period, const std::string &format, const T&... args) { info(format); }
+  inline void info_throttle(float period, const std::string& format, const T&... args)
+  {
+    info(format);
+  }
 
   template <typename... T>
-  inline void warn(const std::string &format, const T&... args) {_log(stderr, "WARN", format, args...);}
+  inline void warn(const std::string& format, const T&... args)
+  {
+    _log(stderr, "WARN", format, args...);
+  }
   template <typename... T>
-  inline void warn_throttle(float period, const std::string &format, const T&... args) { warn(format); }
+  inline void warn_throttle(float period, const std::string& format, const T&... args)
+  {
+    warn(format);
+  }
 
   template <typename... T>
-  inline void error(const std::string &format, const T&... args) {_log(stderr, "ERROR", format, args...);}
+  inline void error(const std::string& format, const T&... args)
+  {
+    _log(stderr, "ERROR", format, args...);
+  }
   template <typename... T>
-  inline void error_throttle(float period, const std::string &format, const T&... args) { error(format); }
+  inline void error_throttle(float period, const std::string& format, const T&... args)
+  {
+    error(format);
+  }
 
   template <typename... T>
-  inline void fatal(const std::string &format, const T&... args) {_log(stderr, "FATAL", format, args...);}
+  inline void fatal(const std::string& format, const T&... args)
+  {
+    _log(stderr, "FATAL", format, args...);
+  }
   template <typename... T>
-  inline void fatal_throttle(float period, const std::string &format, const T&... args) { fatal(format); }
+  inline void fatal_throttle(float period, const std::string& format, const T&... args)
+  {
+    fatal(format);
+  }
 
 private:
-  template <typename ... T>
-  inline void _log(FILE *fs, const std::string &name, const std::string &format, const T&... args)
+  template <typename... T>
+  inline void _log(FILE* fs, const std::string& name, const std::string& format, const T&... args)
   {
     std::stringstream ss;
     ss << "[mavrosflight][" << name << "]: " << format << std::endl;
     fprintf(fs, ss.str().c_str(), args...);
   }
-
 };
 } // namespace mavrosflight
 

--- a/rosflight/include/rosflight/mavrosflight/logger_interface.h
+++ b/rosflight/include/rosflight/mavrosflight/logger_interface.h
@@ -59,65 +59,65 @@ class LoggerInterface
 {
 public:
   template <typename... T>
-  void debug(const std::string& format, T... args)
+  void debug(const std::string& format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.debug(format, args...);
   }
   template <typename... T>
-  void debug_throttle(float period, const std::string& format, T... args)
+  void debug_throttle(float period, const std::string& format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.debug_throttle(format, args...);
   }
 
   template <typename... T>
-  void info(const std::string& format, T... args)
+  void info(const std::string& format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.info(format, args...);
   }
   template <typename... T>
-  void info_throttle(float period, const std::string& format, T... args)
+  void info_throttle(float period, const std::string& format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.info_throttle(format, args...);
   }
 
   template <typename... T>
-  void warn(const std::string& format, T... args)
+  void warn(const std::string& format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.warn(format, args...);
   }
   template <typename... T>
-  void warn_throttle(float period, const std::string& format, T... args)
+  void warn_throttle(float period, const std::string& format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.warn_throttle(format, args...);
   }
 
   template <typename... T>
-  void error(const std::string& format, T... args)
+  void error(const std::string& format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.error(format, args...);
   }
   template <typename... T>
-  void error_throttle(float period, const std::string& format, T... args)
+  void error_throttle(float period, const std::string& format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.error_throttle(format, args...);
   }
 
   template <typename... T>
-  void fatal(const std::string& format, T... args)
+  void fatal(const std::string& format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.fatal(format, args...);
   }
   template <typename... T>
-  void fatal_throttle(float period, const std::string& format, T... args)
+  void fatal_throttle(float period, const std::string& format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
     derived.fatal_throttle(format, args...);
@@ -131,25 +131,35 @@ public:
 class DefaultLogger : public LoggerInterface<DefaultLogger>
 {
 public:
-  inline void debug(const std::string &format, T... args) {_log(stdout, "DEBUG", format, args...);}
-  inline void debug_throttle(float period, const std::string &format, T... args) { debug(format); }
+  template <typename... T>
+  inline void debug(const std::string &format, const T&... args) {_log(stdout, "DEBUG", format, args...);}
+  template <typename... T>
+  inline void debug_throttle(float period, const std::string &format, const T&... args) { debug(format); }
 
-  inline void info(const std::string &format, T... args) {_log(stdout, "INFO", format, args...);}
-  inline void info_throttle(float period, const std::string &format, T... args) { info(format); }
+  template <typename... T>
+  inline void info(const std::string &format, const T&... args) {_log(stdout, "INFO", format, args...);}
+  template <typename... T>
+  inline void info_throttle(float period, const std::string &format, const T&... args) { info(format); }
 
-  inline void warn(const std::string &format, T... args) {_log(stderr, "WARN", format, args...);}
-  inline void warn_throttle(float period, const std::string &format, T... args) { warn(format); }
+  template <typename... T>
+  inline void warn(const std::string &format, const T&... args) {_log(stderr, "WARN", format, args...);}
+  template <typename... T>
+  inline void warn_throttle(float period, const std::string &format, const T&... args) { warn(format); }
 
-  inline void error(const std::string &format, T... args) {_log(stderr, "ERROR", format, args...);}
-  inline void error_throttle(float period, const std::string &format, T... args) { error(format); }
+  template <typename... T>
+  inline void error(const std::string &format, const T&... args) {_log(stderr, "ERROR", format, args...);}
+  template <typename... T>
+  inline void error_throttle(float period, const std::string &format, const T&... args) { error(format); }
 
-  inline void fatal(const std::string &format, T... args) {_log(stderr, "FATAL", format, args...);}
-  inline void fatal_throttle(float period, const std::string &format, T... args) { fatal(format); }
+  template <typename... T>
+  inline void fatal(const std::string &format, const T&... args) {_log(stderr, "FATAL", format, args...);}
+  template <typename... T>
+  inline void fatal_throttle(float period, const std::string &format, const T&... args) { fatal(format); }
 };
 
 private:
   template <typename ... T>
-  inline void _log(FILE *fs, const std::string &name, const std::string &format, T... args)
+  inline void _log(FILE *fs, const std::string &name, const std::string &format, const T&... args)
   {
     std::stringstream ss;
     ss << "[mavrosflight][" << name << "]: " << format << std::endl;

--- a/rosflight/include/rosflight/mavrosflight/logger_interface.h
+++ b/rosflight/include/rosflight/mavrosflight/logger_interface.h
@@ -79,10 +79,19 @@ class DefaultLogger : public LoggerInterface
 {
 public:
   inline void debug(const std::string &message) override { std::cout << "[mavrosflight][DEBUG]: " << message << std::endl; }
-  inline void  info(const std::string &message) override { std::cout << "[mavrosflight][INFO]: " << message << std::endl; }
-  inline void  warn(const std::string &message) override { std::cerr << "[mavrosflight][WARN]: " << message << std::endl; }
+  inline void debug_throttle(float rate, const std::string &message) override { debug(message); }
+
+  inline void info(const std::string &message) override { std::cout << "[mavrosflight][INFO]: " << message << std::endl; }
+  inline void info_throttle(float rate, const std::string &message) override { info(message); }
+
+  inline void warn(const std::string &message) override { std::cerr << "[mavrosflight][WARN]: " << message << std::endl; }
+  inline void warn_throttle(float rate, const std::string &message) override { warn(message); }
+
   inline void error(const std::string &message) override { std::cerr << "[mavrosflight][ERROR]: " << message << std::endl; }
+  inline void error_throttle(float rate, const std::string &message) override { error(message); }
+
   inline void fatal(const std::string &message) override { std::cerr << "[mavrosflight][FATAL]: " << message << std::endl; }
+  inline void fatal_throttle(float rate, const std::string &message) override { fatal(message); }
 };
 
 } // namespace mavrosflight

--- a/rosflight/include/rosflight/mavrosflight/logger_interface.h
+++ b/rosflight/include/rosflight/mavrosflight/logger_interface.h
@@ -1,0 +1,81 @@
+/*
+ * Software License Agreement (BSD-3 License)
+ *
+ * Copyright (c) 2018 Daniel Koch.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file logger_interface.h
+ * @author Daniel Koch <danielpkoch@gmail.com>
+ */
+
+#ifndef MAVROSFLIGHT_LOGGER_INTERFACE_H
+#define MAVROSFLIGHT_LOGGER_INTERFACE_H
+
+#include <iostream>
+#include <string>
+
+namespace mavrosflight
+{
+
+/**
+ * \class LoggerInterface
+ * \brief Abstract base class for message handler
+ *
+ * The implementations of this class define how messages are displayed, logged,
+ * etc. To create custom behavior, derive from this base class and override the
+ * pure virtual functions.
+ */
+class LoggerInterface
+{
+public:
+  virtual void debug(const std::string& message) = 0;
+  virtual void  info(const std::string& message) = 0;
+  virtual void  warn(const std::string& message) = 0;
+  virtual void error(const std::string& message) = 0;
+  virtual void fatal(const std::string& message) = 0;
+};
+
+/**
+ * \class DefaultLogger
+ * \brief Default logger that outputs to stdout and stderr
+ */
+class DefaultLogger : public LoggerInterface
+{
+public:
+  inline void debug(const std::string &message) override { std::cout << "[mavrosflight][DEBUG]: " << message << std::endl; }
+  inline void  info(const std::string &message) override { std::cout << "[mavrosflight][INFO]: " << message << std::endl; }
+  inline void  warn(const std::string &message) override { std::cerr << "[mavrosflight][WARN]: " << message << std::endl; }
+  inline void error(const std::string &message) override { std::cerr << "[mavrosflight][ERROR]: " << message << std::endl; }
+  inline void fatal(const std::string &message) override { std::cerr << "[mavrosflight][FATAL]: " << message << std::endl; }
+};
+
+} // namespace mavrosflight
+
+#endif // MAVROSFLIGHT_LOGGER_INTERFACE_H

--- a/rosflight/include/rosflight/mavrosflight/logger_interface.h
+++ b/rosflight/include/rosflight/mavrosflight/logger_interface.h
@@ -68,7 +68,7 @@ public:
   void debug_throttle(float period, const std::string& format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
-    derived.debug_throttle(format, args...);
+    derived.debug_throttle(period, format, args...);
   }
 
   template <typename... T>
@@ -81,7 +81,7 @@ public:
   void info_throttle(float period, const std::string& format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
-    derived.info_throttle(format, args...);
+    derived.info_throttle(period, format, args...);
   }
 
   template <typename... T>
@@ -94,7 +94,7 @@ public:
   void warn_throttle(float period, const std::string& format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
-    derived.warn_throttle(format, args...);
+    derived.warn_throttle(period, format, args...);
   }
 
   template <typename... T>
@@ -107,7 +107,7 @@ public:
   void error_throttle(float period, const std::string& format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
-    derived.error_throttle(format, args...);
+    derived.error_throttle(period, format, args...);
   }
 
   template <typename... T>
@@ -120,7 +120,7 @@ public:
   void fatal_throttle(float period, const std::string& format, const T&... args)
   {
     Derived& derived = static_cast<Derived&>(*this);
-    derived.fatal_throttle(format, args...);
+    derived.fatal_throttle(period, format, args...);
   }
 };
 

--- a/rosflight/include/rosflight/mavrosflight/mavrosflight.h
+++ b/rosflight/include/rosflight/mavrosflight/mavrosflight.h
@@ -53,6 +53,7 @@
 
 namespace mavrosflight
 {
+template<typename DerivedLogger>
 class MavROSflight
 {
 public:
@@ -61,7 +62,7 @@ public:
    * \param mavlink_comm Reference to a MavlinkComm object (serial or UDP)
    * \param baud_rate Serial communication baud rate
    */
-  MavROSflight(MavlinkComm& mavlink_comm, LoggerInterface& logger, uint8_t sysid = 1, uint8_t compid = 50);
+  MavROSflight(MavlinkComm& mavlink_comm, LoggerInterface<DerivedLogger>& logger, uint8_t sysid = 1, uint8_t compid = 50);
 
   /**
    * \brief Stops communication and closes the serial port before the object is destroyed
@@ -70,8 +71,8 @@ public:
 
   // public member objects
   MavlinkComm& comm;
-  ParamManager param;
-  TimeManager time;
+  ParamManager<DerivedLogger> param;
+  TimeManager<DerivedLogger> time;
 
 private:
   // member variables

--- a/rosflight/include/rosflight/mavrosflight/mavrosflight.h
+++ b/rosflight/include/rosflight/mavrosflight/mavrosflight.h
@@ -37,6 +37,7 @@
 #ifndef MAVROSFLIGHT_MAVROSFLIGHT_H
 #define MAVROSFLIGHT_MAVROSFLIGHT_H
 
+#include <rosflight/mavrosflight/logger_interface.h>
 #include <rosflight/mavrosflight/mavlink_bridge.h>
 #include <rosflight/mavrosflight/mavlink_comm.h>
 #include <rosflight/mavrosflight/param_manager.h>
@@ -60,7 +61,7 @@ public:
    * \param mavlink_comm Reference to a MavlinkComm object (serial or UDP)
    * \param baud_rate Serial communication baud rate
    */
-  MavROSflight(MavlinkComm& mavlink_comm, uint8_t sysid = 1, uint8_t compid = 50);
+  MavROSflight(MavlinkComm& mavlink_comm, LoggerInterface& logger, uint8_t sysid = 1, uint8_t compid = 50);
 
   /**
    * \brief Stops communication and closes the serial port before the object is destroyed

--- a/rosflight/include/rosflight/mavrosflight/mavrosflight.h
+++ b/rosflight/include/rosflight/mavrosflight/mavrosflight.h
@@ -53,7 +53,7 @@
 
 namespace mavrosflight
 {
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 class MavROSflight
 {
 public:
@@ -62,7 +62,10 @@ public:
    * \param mavlink_comm Reference to a MavlinkComm object (serial or UDP)
    * \param baud_rate Serial communication baud rate
    */
-  MavROSflight(MavlinkComm& mavlink_comm, LoggerInterface<DerivedLogger>& logger, uint8_t sysid = 1, uint8_t compid = 50);
+  MavROSflight(MavlinkComm& mavlink_comm,
+               LoggerInterface<DerivedLogger>& logger,
+               uint8_t sysid = 1,
+               uint8_t compid = 50);
 
   /**
    * \brief Stops communication and closes the serial port before the object is destroyed

--- a/rosflight/include/rosflight/mavrosflight/param_manager.h
+++ b/rosflight/include/rosflight/mavrosflight/param_manager.h
@@ -37,6 +37,7 @@
 #ifndef MAVROSFLIGHT_PARAM_MANAGER_H
 #define MAVROSFLIGHT_PARAM_MANAGER_H
 
+#include <rosflight/mavrosflight/logger_interface.h>
 #include <rosflight/mavrosflight/mavlink_bridge.h>
 #include <rosflight/mavrosflight/mavlink_comm.h>
 #include <rosflight/mavrosflight/mavlink_listener_interface.h>
@@ -55,7 +56,7 @@ namespace mavrosflight
 class ParamManager : public MavlinkListenerInterface
 {
 public:
-  ParamManager(MavlinkComm *const comm);
+  ParamManager(MavlinkComm *const comm, LoggerInterface& logger);
   ~ParamManager();
 
   virtual void handle_mavlink_message(const mavlink_message_t &msg);
@@ -106,6 +107,8 @@ private:
   ros::Timer param_set_timer_;
   bool param_set_in_progress_;
   void param_set_timer_callback(const ros::TimerEvent &event);
+
+  LoggerInterface& logger_;
 };
 
 } // namespace mavrosflight

--- a/rosflight/include/rosflight/mavrosflight/param_manager.h
+++ b/rosflight/include/rosflight/mavrosflight/param_manager.h
@@ -53,10 +53,11 @@
 
 namespace mavrosflight
 {
+template<typename DerivedLogger>
 class ParamManager : public MavlinkListenerInterface
 {
 public:
-  ParamManager(MavlinkComm *const comm, LoggerInterface& logger);
+  ParamManager(MavlinkComm *const comm, LoggerInterface<DerivedLogger>& logger);
   ~ParamManager();
 
   virtual void handle_mavlink_message(const mavlink_message_t &msg);
@@ -108,7 +109,7 @@ private:
   bool param_set_in_progress_;
   void param_set_timer_callback(const ros::TimerEvent &event);
 
-  LoggerInterface& logger_;
+  LoggerInterface<DerivedLogger>& logger_;
 };
 
 } // namespace mavrosflight

--- a/rosflight/include/rosflight/mavrosflight/param_manager.h
+++ b/rosflight/include/rosflight/mavrosflight/param_manager.h
@@ -53,11 +53,11 @@
 
 namespace mavrosflight
 {
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 class ParamManager : public MavlinkListenerInterface
 {
 public:
-  ParamManager(MavlinkComm *const comm, LoggerInterface<DerivedLogger>& logger);
+  ParamManager(MavlinkComm *const comm, LoggerInterface<DerivedLogger> &logger);
   ~ParamManager();
 
   virtual void handle_mavlink_message(const mavlink_message_t &msg);
@@ -109,7 +109,7 @@ private:
   bool param_set_in_progress_;
   void param_set_timer_callback(const ros::TimerEvent &event);
 
-  LoggerInterface<DerivedLogger>& logger_;
+  LoggerInterface<DerivedLogger> &logger_;
 };
 
 } // namespace mavrosflight

--- a/rosflight/include/rosflight/mavrosflight/time_manager.h
+++ b/rosflight/include/rosflight/mavrosflight/time_manager.h
@@ -37,6 +37,7 @@
 #ifndef MAVROSFLIGHT_TIME_MANAGER_H
 #define MAVROSFLIGHT_TIME_MANAGER_H
 
+#include <rosflight/mavrosflight/logger_interface.h>
 #include <rosflight/mavrosflight/mavlink_bridge.h>
 #include <rosflight/mavrosflight/mavlink_comm.h>
 #include <rosflight/mavrosflight/mavlink_listener_interface.h>
@@ -51,7 +52,7 @@ namespace mavrosflight
 class TimeManager : MavlinkListenerInterface
 {
 public:
-  TimeManager(MavlinkComm *comm);
+  TimeManager(MavlinkComm *comm, LoggerInterface& logger);
 
   virtual void handle_mavlink_message(const mavlink_message_t &msg);
 
@@ -69,6 +70,8 @@ private:
   ros::Duration offset_;
 
   bool initialized_;
+
+  LoggerInterface& logger_;
 };
 
 } // namespace mavrosflight

--- a/rosflight/include/rosflight/mavrosflight/time_manager.h
+++ b/rosflight/include/rosflight/mavrosflight/time_manager.h
@@ -49,11 +49,11 @@
 
 namespace mavrosflight
 {
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 class TimeManager : MavlinkListenerInterface
 {
 public:
-  TimeManager(MavlinkComm *comm, LoggerInterface<DerivedLogger>& logger);
+  TimeManager(MavlinkComm *comm, LoggerInterface<DerivedLogger> &logger);
 
   virtual void handle_mavlink_message(const mavlink_message_t &msg);
 
@@ -72,7 +72,7 @@ private:
 
   bool initialized_;
 
-  LoggerInterface<DerivedLogger>& logger_;
+  LoggerInterface<DerivedLogger> &logger_;
 };
 
 } // namespace mavrosflight

--- a/rosflight/include/rosflight/mavrosflight/time_manager.h
+++ b/rosflight/include/rosflight/mavrosflight/time_manager.h
@@ -49,10 +49,11 @@
 
 namespace mavrosflight
 {
+template<typename DerivedLogger>
 class TimeManager : MavlinkListenerInterface
 {
 public:
-  TimeManager(MavlinkComm *comm, LoggerInterface& logger);
+  TimeManager(MavlinkComm *comm, LoggerInterface<DerivedLogger>& logger);
 
   virtual void handle_mavlink_message(const mavlink_message_t &msg);
 
@@ -71,7 +72,7 @@ private:
 
   bool initialized_;
 
-  LoggerInterface& logger_;
+  LoggerInterface<DerivedLogger>& logger_;
 };
 
 } // namespace mavrosflight

--- a/rosflight/include/rosflight/ros_logger.h
+++ b/rosflight/include/rosflight/ros_logger.h
@@ -54,16 +54,16 @@ namespace rosflight
 class ROSLogger : public mavrosflight::LoggerInterface<ROSLogger>
 {
 public:
-  template <typename... T>
-  inline void debug(const char* format, const T&... args)
+  template <typename... Args>
+  inline void debug(const char* format, const Args&... args)
   {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-security"
     ROS_DEBUG(format, args...);
 #pragma GCC diagnostic pop
   }
-  template <typename... T>
-  inline void debug_throttle(float period, const char* format, const T&... args)
+  template <typename... Args>
+  inline void debug_throttle(float period, const char* format, const Args&... args)
   {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-security"
@@ -71,16 +71,16 @@ public:
 #pragma GCC diagnostic pop
   }
 
-  template <typename... T>
-  inline void info(const char* format, const T&... args)
+  template <typename... Args>
+  inline void info(const char* format, const Args&... args)
   {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-security"
     ROS_INFO(format, args...);
 #pragma GCC diagnostic pop
   }
-  template <typename... T>
-  inline void info_throttle(float period, const char* format, const T&... args)
+  template <typename... Args>
+  inline void info_throttle(float period, const char* format, const Args&... args)
   {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-security"
@@ -88,16 +88,16 @@ public:
 #pragma GCC diagnostic pop
   }
 
-  template <typename... T>
-  inline void warn(const char* format, const T&... args)
+  template <typename... Args>
+  inline void warn(const char* format, const Args&... args)
   {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-security"
     ROS_WARN(format, args...);
 #pragma GCC diagnostic pop
   }
-  template <typename... T>
-  inline void warn_throttle(float period, const char* format, const T&... args)
+  template <typename... Args>
+  inline void warn_throttle(float period, const char* format, const Args&... args)
   {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-security"
@@ -105,16 +105,16 @@ public:
 #pragma GCC diagnostic pop
   }
 
-  template <typename... T>
-  inline void error(const char* format, const T&... args)
+  template <typename... Args>
+  inline void error(const char* format, const Args&... args)
   {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-security"
     ROS_ERROR(format, args...);
 #pragma GCC diagnostic pop
   }
-  template <typename... T>
-  inline void error_throttle(float period, const char* format, const T&... args)
+  template <typename... Args>
+  inline void error_throttle(float period, const char* format, const Args&... args)
   {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-security"
@@ -122,16 +122,16 @@ public:
 #pragma GCC diagnostic pop
   }
 
-  template <typename... T>
-  inline void fatal(const char* format, const T&... args)
+  template <typename... Args>
+  inline void fatal(const char* format, const Args&... args)
   {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-security"
     ROS_FATAL(format, args...);
 #pragma GCC diagnostic pop
   }
-  template <typename... T>
-  inline void fatal_throttle(float period, const char* format, const T&... args)
+  template <typename... Args>
+  inline void fatal_throttle(float period, const char* format, const Args&... args)
   {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-security"

--- a/rosflight/include/rosflight/ros_logger.h
+++ b/rosflight/include/rosflight/ros_logger.h
@@ -57,86 +57,86 @@ public:
   template <typename... T>
   inline void debug(const char* format, const T&... args)
   {
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wformat-security"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
     ROS_DEBUG(format, args...);
-    #pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
   }
   template <typename... T>
   inline void debug_throttle(float period, const char* format, const T&... args)
   {
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wformat-security"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
     ROS_DEBUG_THROTTLE(period, format, args...);
-    #pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
   }
 
   template <typename... T>
   inline void info(const char* format, const T&... args)
   {
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wformat-security"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
     ROS_INFO(format, args...);
-    #pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
   }
   template <typename... T>
   inline void info_throttle(float period, const char* format, const T&... args)
   {
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wformat-security"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
     ROS_INFO_THROTTLE(period, format, args...);
-    #pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
   }
 
   template <typename... T>
   inline void warn(const char* format, const T&... args)
   {
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wformat-security"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
     ROS_WARN(format, args...);
-    #pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
   }
   template <typename... T>
   inline void warn_throttle(float period, const char* format, const T&... args)
   {
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wformat-security"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
     ROS_WARN_THROTTLE(period, format, args...);
-    #pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
   }
 
   template <typename... T>
   inline void error(const char* format, const T&... args)
   {
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wformat-security"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
     ROS_ERROR(format, args...);
-    #pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
   }
   template <typename... T>
   inline void error_throttle(float period, const char* format, const T&... args)
   {
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wformat-security"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
     ROS_ERROR_THROTTLE(period, format, args...);
-    #pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
   }
 
   template <typename... T>
   inline void fatal(const char* format, const T&... args)
   {
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wformat-security"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
     ROS_FATAL(format, args...);
-    #pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
   }
   template <typename... T>
   inline void fatal_throttle(float period, const char* format, const T&... args)
   {
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wformat-security"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
     ROS_FATAL_THROTTLE(period, format, args...);
-    #pragma GCC diagnostic pop
+#pragma GCC diagnostic pop
   }
 };
 

--- a/rosflight/include/rosflight/ros_logger.h
+++ b/rosflight/include/rosflight/ros_logger.h
@@ -1,7 +1,7 @@
 /*
  * Software License Agreement (BSD-3 License)
  *
- * Copyright (c) 2018 Daniel Koch.
+ * Copyright (c) 2020 Jacob Willis.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,7 +32,7 @@
 
 /**
  * @file ros_logger.h
- * @author Daniel Koch <danielpkoch@gmail.com>
+ * @author Jacob Willis <jbwillis272@gmail.com>
  */
 
 #ifndef ROSFLIGHT_ROS_LOGGER_H

--- a/rosflight/include/rosflight/ros_logger.h
+++ b/rosflight/include/rosflight/ros_logger.h
@@ -44,7 +44,6 @@
 
 namespace rosflight
 {
-
 /**
  * @class ROSLogger
  * @brief Logger implementation for ROS environments
@@ -56,29 +55,59 @@ class ROSLogger : public mavrosflight::LoggerInterface<ROSLogger>
 {
 public:
   template <typename... T>
-  inline void debug(const std::string &format, const T&... args) { ROS_DEBUG(format.c_str(), args...); }
+  inline void debug(const std::string &format, const T &... args)
+  {
+    ROS_DEBUG(format.c_str(), args...);
+  }
   template <typename... T>
-  inline void debug_throttle(float period, const std::string &format, const T&... args) { ROS_DEBUG_THROTTLE(period, format.c_str(), args...); }
+  inline void debug_throttle(float period, const std::string &format, const T &... args)
+  {
+    ROS_DEBUG_THROTTLE(period, format.c_str(), args...);
+  }
 
   template <typename... T>
-  inline void info(const std::string &format, const T&... args) { ROS_INFO(format.c_str(), args...); }
+  inline void info(const std::string &format, const T &... args)
+  {
+    ROS_INFO(format.c_str(), args...);
+  }
   template <typename... T>
-  inline void info_throttle(float period, const std::string &format, const T&... args) { ROS_INFO_THROTTLE(period, format.c_str(), args...); }
+  inline void info_throttle(float period, const std::string &format, const T &... args)
+  {
+    ROS_INFO_THROTTLE(period, format.c_str(), args...);
+  }
 
   template <typename... T>
-  inline void warn(const std::string &format, const T&... args) { ROS_WARN(format.c_str(), args...); }
+  inline void warn(const std::string &format, const T &... args)
+  {
+    ROS_WARN(format.c_str(), args...);
+  }
   template <typename... T>
-  inline void warn_throttle(float period, const std::string &format, const T&... args) { ROS_WARN_THROTTLE(period, format.c_str(), args...); }
+  inline void warn_throttle(float period, const std::string &format, const T &... args)
+  {
+    ROS_WARN_THROTTLE(period, format.c_str(), args...);
+  }
 
   template <typename... T>
-  inline void error(const std::string &format, const T&... args) { ROS_ERROR(format.c_str(), args...); }
+  inline void error(const std::string &format, const T &... args)
+  {
+    ROS_ERROR(format.c_str(), args...);
+  }
   template <typename... T>
-  inline void error_throttle(float period, const std::string &format, const T&... args) { ROS_ERROR_THROTTLE(period, format.c_str(), args...); }
+  inline void error_throttle(float period, const std::string &format, const T &... args)
+  {
+    ROS_ERROR_THROTTLE(period, format.c_str(), args...);
+  }
 
   template <typename... T>
-  inline void fatal(const std::string &format, const T&... args) { ROS_FATAL(format.c_str(), args...); }
+  inline void fatal(const std::string &format, const T &... args)
+  {
+    ROS_FATAL(format.c_str(), args...);
+  }
   template <typename... T>
-  inline void fatal_throttle(float period, const std::string &format, const T&... args) { ROS_FATAL_THROTTLE(period, format.c_str(), args...); }
+  inline void fatal_throttle(float period, const std::string &format, const T &... args)
+  {
+    ROS_FATAL_THROTTLE(period, format.c_str(), args...);
+  }
 };
 
 } // namespace rosflight

--- a/rosflight/include/rosflight/ros_logger.h
+++ b/rosflight/include/rosflight/ros_logger.h
@@ -55,56 +55,56 @@ class ROSLogger : public mavrosflight::LoggerInterface<ROSLogger>
 {
 public:
   template <typename... T>
-  inline void debug(const char* format, const T &... args)
+  inline void debug(const char* format, const T&... args)
   {
     ROS_DEBUG(format, args...);
   }
   template <typename... T>
-  inline void debug_throttle(float period, const char* format, const T &... args)
+  inline void debug_throttle(float period, const char* format, const T&... args)
   {
     ROS_DEBUG_THROTTLE(period, format, args...);
   }
 
   template <typename... T>
-  inline void info(const char* format, const T &... args)
+  inline void info(const char* format, const T&... args)
   {
     ROS_INFO(format, args...);
   }
   template <typename... T>
-  inline void info_throttle(float period, const char* format, const T &... args)
+  inline void info_throttle(float period, const char* format, const T&... args)
   {
     ROS_INFO_THROTTLE(period, format, args...);
   }
 
   template <typename... T>
-  inline void warn(const char* format, const T &... args)
+  inline void warn(const char* format, const T&... args)
   {
     ROS_WARN(format, args...);
   }
   template <typename... T>
-  inline void warn_throttle(float period, const char* format, const T &... args)
+  inline void warn_throttle(float period, const char* format, const T&... args)
   {
     ROS_WARN_THROTTLE(period, format, args...);
   }
 
   template <typename... T>
-  inline void error(const char* format, const T &... args)
+  inline void error(const char* format, const T&... args)
   {
     ROS_ERROR(format, args...);
   }
   template <typename... T>
-  inline void error_throttle(float period, const char* format, const T &... args)
+  inline void error_throttle(float period, const char* format, const T&... args)
   {
     ROS_ERROR_THROTTLE(period, format, args...);
   }
 
   template <typename... T>
-  inline void fatal(const char* format, const T &... args)
+  inline void fatal(const char* format, const T&... args)
   {
     ROS_FATAL(format, args...);
   }
   template <typename... T>
-  inline void fatal_throttle(float period, const char* format, const T &... args)
+  inline void fatal_throttle(float period, const char* format, const T&... args)
   {
     ROS_FATAL_THROTTLE(period, format, args...);
   }

--- a/rosflight/include/rosflight/ros_logger.h
+++ b/rosflight/include/rosflight/ros_logger.h
@@ -31,12 +31,12 @@
  */
 
 /**
- * @file logger_ros.h
+ * @file ros_logger.h
  * @author Daniel Koch <danielpkoch@gmail.com>
  */
 
-#ifndef ROSFLIGHT_LOGGER_ROS_H
-#define ROSFLIGHT_LOGGER_ROS_H
+#ifndef ROSFLIGHT_ROS_LOGGER_H
+#define ROSFLIGHT_ROS_LOGGER_H
 
 #include <rosflight/mavrosflight/logger_interface.h>
 
@@ -46,13 +46,13 @@ namespace rosflight
 {
 
 /**
- * @class LoggerROS
+ * @class ROSLogger
  * @brief Logger implementation for ROS environments
  *
  * This is a convenience logger implementation for ROS-based projects.
  * The implementation simply forwards messages to the appropriate rosconsole loggers.
  */
-class LoggerROS : public mavrosflight::LoggerInterface<LoggerROS>
+class ROSLogger : public mavrosflight::LoggerInterface<ROSLogger>
 {
 public:
   template <typename... T>
@@ -83,4 +83,4 @@ public:
 
 } // namespace rosflight
 
-#endif // ROSFLIGHT_LOGGER_ROS_H
+#endif // ROSFLIGHT_ROS_LOGGER_H

--- a/rosflight/include/rosflight/ros_logger.h
+++ b/rosflight/include/rosflight/ros_logger.h
@@ -55,58 +55,58 @@ class ROSLogger : public mavrosflight::LoggerInterface<ROSLogger>
 {
 public:
   template <typename... T>
-  inline void debug(const std::string &format, const T &... args)
+  inline void debug(const char* format, const T &... args)
   {
-    ROS_DEBUG(format.c_str(), args...);
+    ROS_DEBUG(format, args...);
   }
   template <typename... T>
-  inline void debug_throttle(float period, const std::string &format, const T &... args)
+  inline void debug_throttle(float period, const char* format, const T &... args)
   {
-    ROS_DEBUG_THROTTLE(period, format.c_str(), args...);
-  }
-
-  template <typename... T>
-  inline void info(const std::string &format, const T &... args)
-  {
-    ROS_INFO(format.c_str(), args...);
-  }
-  template <typename... T>
-  inline void info_throttle(float period, const std::string &format, const T &... args)
-  {
-    ROS_INFO_THROTTLE(period, format.c_str(), args...);
+    ROS_DEBUG_THROTTLE(period, format, args...);
   }
 
   template <typename... T>
-  inline void warn(const std::string &format, const T &... args)
+  inline void info(const char* format, const T &... args)
   {
-    ROS_WARN(format.c_str(), args...);
+    ROS_INFO(format, args...);
   }
   template <typename... T>
-  inline void warn_throttle(float period, const std::string &format, const T &... args)
+  inline void info_throttle(float period, const char* format, const T &... args)
   {
-    ROS_WARN_THROTTLE(period, format.c_str(), args...);
-  }
-
-  template <typename... T>
-  inline void error(const std::string &format, const T &... args)
-  {
-    ROS_ERROR(format.c_str(), args...);
-  }
-  template <typename... T>
-  inline void error_throttle(float period, const std::string &format, const T &... args)
-  {
-    ROS_ERROR_THROTTLE(period, format.c_str(), args...);
+    ROS_INFO_THROTTLE(period, format, args...);
   }
 
   template <typename... T>
-  inline void fatal(const std::string &format, const T &... args)
+  inline void warn(const char* format, const T &... args)
   {
-    ROS_FATAL(format.c_str(), args...);
+    ROS_WARN(format, args...);
   }
   template <typename... T>
-  inline void fatal_throttle(float period, const std::string &format, const T &... args)
+  inline void warn_throttle(float period, const char* format, const T &... args)
   {
-    ROS_FATAL_THROTTLE(period, format.c_str(), args...);
+    ROS_WARN_THROTTLE(period, format, args...);
+  }
+
+  template <typename... T>
+  inline void error(const char* format, const T &... args)
+  {
+    ROS_ERROR(format, args...);
+  }
+  template <typename... T>
+  inline void error_throttle(float period, const char* format, const T &... args)
+  {
+    ROS_ERROR_THROTTLE(period, format, args...);
+  }
+
+  template <typename... T>
+  inline void fatal(const char* format, const T &... args)
+  {
+    ROS_FATAL(format, args...);
+  }
+  template <typename... T>
+  inline void fatal_throttle(float period, const char* format, const T &... args)
+  {
+    ROS_FATAL_THROTTLE(period, format, args...);
   }
 };
 

--- a/rosflight/include/rosflight/ros_logger.h
+++ b/rosflight/include/rosflight/ros_logger.h
@@ -57,56 +57,86 @@ public:
   template <typename... T>
   inline void debug(const char* format, const T&... args)
   {
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wformat-security"
     ROS_DEBUG(format, args...);
+    #pragma GCC diagnostic pop
   }
   template <typename... T>
   inline void debug_throttle(float period, const char* format, const T&... args)
   {
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wformat-security"
     ROS_DEBUG_THROTTLE(period, format, args...);
+    #pragma GCC diagnostic pop
   }
 
   template <typename... T>
   inline void info(const char* format, const T&... args)
   {
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wformat-security"
     ROS_INFO(format, args...);
+    #pragma GCC diagnostic pop
   }
   template <typename... T>
   inline void info_throttle(float period, const char* format, const T&... args)
   {
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wformat-security"
     ROS_INFO_THROTTLE(period, format, args...);
+    #pragma GCC diagnostic pop
   }
 
   template <typename... T>
   inline void warn(const char* format, const T&... args)
   {
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wformat-security"
     ROS_WARN(format, args...);
+    #pragma GCC diagnostic pop
   }
   template <typename... T>
   inline void warn_throttle(float period, const char* format, const T&... args)
   {
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wformat-security"
     ROS_WARN_THROTTLE(period, format, args...);
+    #pragma GCC diagnostic pop
   }
 
   template <typename... T>
   inline void error(const char* format, const T&... args)
   {
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wformat-security"
     ROS_ERROR(format, args...);
+    #pragma GCC diagnostic pop
   }
   template <typename... T>
   inline void error_throttle(float period, const char* format, const T&... args)
   {
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wformat-security"
     ROS_ERROR_THROTTLE(period, format, args...);
+    #pragma GCC diagnostic pop
   }
 
   template <typename... T>
   inline void fatal(const char* format, const T&... args)
   {
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wformat-security"
     ROS_FATAL(format, args...);
+    #pragma GCC diagnostic pop
   }
   template <typename... T>
   inline void fatal_throttle(float period, const char* format, const T&... args)
   {
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wformat-security"
     ROS_FATAL_THROTTLE(period, format, args...);
+    #pragma GCC diagnostic pop
   }
 };
 

--- a/rosflight/include/rosflight/rosflight_io.h
+++ b/rosflight/include/rosflight/rosflight_io.h
@@ -80,6 +80,7 @@
 #include <rosflight/mavrosflight/mavlink_listener_interface.h>
 #include <rosflight/mavrosflight/mavrosflight.h>
 #include <rosflight/mavrosflight/param_listener_interface.h>
+#include <rosflight/ros_logger.h>
 
 #include <geometry_msgs/Quaternion.h>
 
@@ -214,7 +215,7 @@ private:
   std::string frame_id_;
 
   mavrosflight::MavlinkComm *mavlink_comm_;
-  mavrosflight::MavROSflight *mavrosflight_;
+  mavrosflight::MavROSflight<rosflight::ROSLogger> *mavrosflight_;
 };
 
 } // namespace rosflight_io

--- a/rosflight/src/mavrosflight/mavrosflight.cpp
+++ b/rosflight/src/mavrosflight/mavrosflight.cpp
@@ -42,10 +42,10 @@ namespace mavrosflight
 {
 using boost::asio::serial_port_base;
 
-MavROSflight::MavROSflight(MavlinkComm &mavlink_comm, uint8_t sysid /* = 1 */, uint8_t compid /* = 50 */) :
+MavROSflight::MavROSflight(MavlinkComm &mavlink_comm, LoggerInterface &logger, uint8_t sysid /* = 1 */, uint8_t compid /* = 50 */) :
   comm(mavlink_comm),
-  param(&comm),
-  time(&comm),
+  param(&comm, logger),
+  time(&comm, logger),
   sysid_(sysid),
   compid_(compid)
 {

--- a/rosflight/src/mavrosflight/mavrosflight.cpp
+++ b/rosflight/src/mavrosflight/mavrosflight.cpp
@@ -35,6 +35,7 @@
  */
 
 #include <rosflight/mavrosflight/mavrosflight.h>
+#include <rosflight/ros_logger.h>
 
 #include <ros/ros.h>
 
@@ -59,5 +60,7 @@ MavROSflight<DerivedLogger>::~MavROSflight()
 {
   comm.close();
 }
+
+template class MavROSflight<rosflight::ROSLogger>;
 
 } // namespace mavrosflight

--- a/rosflight/src/mavrosflight/mavrosflight.cpp
+++ b/rosflight/src/mavrosflight/mavrosflight.cpp
@@ -38,6 +38,8 @@
 
 #if defined(USE_ROS)
 #include <rosflight/ros_logger.h>
+#elif defined(STANDALONE)
+#include <rosflight/mavrosflight/logger_interface.h>
 #endif
 
 #include <ros/ros.h>
@@ -66,6 +68,8 @@ MavROSflight<DerivedLogger>::~MavROSflight()
 
 #if defined(USE_ROS)
 template class MavROSflight<rosflight::ROSLogger>;
+#elif defined(STANDALONE)
+template class MavROSflight<mavrosflight::DefaultLogger>;
 #endif
 
 } // namespace mavrosflight

--- a/rosflight/src/mavrosflight/mavrosflight.cpp
+++ b/rosflight/src/mavrosflight/mavrosflight.cpp
@@ -73,6 +73,8 @@ MavROSflight<DerivedLogger>::~MavROSflight()
 template class MavROSflight<rosflight::ROSLogger>;
 #elif defined(STANDALONE)
 template class MavROSflight<mavrosflight::DefaultLogger>;
+#else
+#error Unknown logging backend supplied for mavrosflight. Define USE_ROS or STANDALONE.
 #endif
 
 } // namespace mavrosflight

--- a/rosflight/src/mavrosflight/mavrosflight.cpp
+++ b/rosflight/src/mavrosflight/mavrosflight.cpp
@@ -42,7 +42,8 @@ namespace mavrosflight
 {
 using boost::asio::serial_port_base;
 
-MavROSflight::MavROSflight(MavlinkComm &mavlink_comm, LoggerInterface &logger, uint8_t sysid /* = 1 */, uint8_t compid /* = 50 */) :
+template<typename DerivedLogger>
+MavROSflight<DerivedLogger>::MavROSflight(MavlinkComm &mavlink_comm, LoggerInterface<DerivedLogger> &logger, uint8_t sysid /* = 1 */, uint8_t compid /* = 50 */) :
   comm(mavlink_comm),
   param(&comm, logger),
   time(&comm, logger),
@@ -53,7 +54,8 @@ MavROSflight::MavROSflight(MavlinkComm &mavlink_comm, LoggerInterface &logger, u
   // comm.open();
 }
 
-MavROSflight::~MavROSflight()
+template<typename DerivedLogger>
+MavROSflight<DerivedLogger>::~MavROSflight()
 {
   comm.close();
 }

--- a/rosflight/src/mavrosflight/mavrosflight.cpp
+++ b/rosflight/src/mavrosflight/mavrosflight.cpp
@@ -35,7 +35,10 @@
  */
 
 #include <rosflight/mavrosflight/mavrosflight.h>
+
+#if defined(USE_ROS)
 #include <rosflight/ros_logger.h>
+#endif
 
 #include <ros/ros.h>
 
@@ -61,6 +64,8 @@ MavROSflight<DerivedLogger>::~MavROSflight()
   comm.close();
 }
 
+#if defined(USE_ROS)
 template class MavROSflight<rosflight::ROSLogger>;
+#endif
 
 } // namespace mavrosflight

--- a/rosflight/src/mavrosflight/mavrosflight.cpp
+++ b/rosflight/src/mavrosflight/mavrosflight.cpp
@@ -48,8 +48,11 @@ namespace mavrosflight
 {
 using boost::asio::serial_port_base;
 
-template<typename DerivedLogger>
-MavROSflight<DerivedLogger>::MavROSflight(MavlinkComm &mavlink_comm, LoggerInterface<DerivedLogger> &logger, uint8_t sysid /* = 1 */, uint8_t compid /* = 50 */) :
+template <typename DerivedLogger>
+MavROSflight<DerivedLogger>::MavROSflight(MavlinkComm &mavlink_comm,
+                                          LoggerInterface<DerivedLogger> &logger,
+                                          uint8_t sysid /* = 1 */,
+                                          uint8_t compid /* = 50 */) :
   comm(mavlink_comm),
   param(&comm, logger),
   time(&comm, logger),
@@ -60,7 +63,7 @@ MavROSflight<DerivedLogger>::MavROSflight(MavlinkComm &mavlink_comm, LoggerInter
   // comm.open();
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 MavROSflight<DerivedLogger>::~MavROSflight()
 {
   comm.close();

--- a/rosflight/src/mavrosflight/mavrosflight.cpp
+++ b/rosflight/src/mavrosflight/mavrosflight.cpp
@@ -39,6 +39,7 @@
 #if defined(USE_ROS)
 #include <rosflight/ros_logger.h>
 #elif defined(STANDALONE)
+#include <rosflight/mavrosflight/default_logger.h>
 #include <rosflight/mavrosflight/logger_interface.h>
 #endif
 

--- a/rosflight/src/mavrosflight/mavrosflight.cpp
+++ b/rosflight/src/mavrosflight/mavrosflight.cpp
@@ -34,14 +34,9 @@
  * \author Daniel Koch <daniel.koch@byu.edu>
  */
 
-#include <rosflight/mavrosflight/mavrosflight.h>
-
-#if defined(USE_ROS)
-#include <rosflight/ros_logger.h>
-#elif defined(STANDALONE)
-#include <rosflight/mavrosflight/default_logger.h>
+#include <rosflight/mavrosflight/logger_adapter.h>
 #include <rosflight/mavrosflight/logger_interface.h>
-#endif
+#include <rosflight/mavrosflight/mavrosflight.h>
 
 #include <ros/ros.h>
 
@@ -70,12 +65,6 @@ MavROSflight<DerivedLogger>::~MavROSflight()
   comm.close();
 }
 
-#if defined(USE_ROS)
-template class MavROSflight<rosflight::ROSLogger>;
-#elif defined(STANDALONE)
-template class MavROSflight<mavrosflight::DefaultLogger>;
-#else
-#error Unknown logging backend supplied for mavrosflight. Define USE_ROS or STANDALONE.
-#endif
+template class MavROSflight<DerivedLoggerType>;
 
 } // namespace mavrosflight

--- a/rosflight/src/mavrosflight/param_manager.cpp
+++ b/rosflight/src/mavrosflight/param_manager.cpp
@@ -36,8 +36,11 @@
 
 #include <ros/ros.h>
 #include <rosflight/mavrosflight/param_manager.h>
-#include <rosflight/ros_logger.h>
 #include <yaml-cpp/yaml.h>
+
+#if defined(USE_ROS)
+#include <rosflight/ros_logger.h>
+#endif
 
 #include <fstream>
 
@@ -411,6 +414,8 @@ void ParamManager<DerivedLogger>::param_set_timer_callback(const ros::TimerEvent
   }
 }
 
+#if defined(USE_ROS)
 template class ParamManager<rosflight::ROSLogger>;
+#endif
 
 } // namespace mavrosflight

--- a/rosflight/src/mavrosflight/param_manager.cpp
+++ b/rosflight/src/mavrosflight/param_manager.cpp
@@ -36,6 +36,7 @@
 
 #include <ros/ros.h>
 #include <rosflight/mavrosflight/param_manager.h>
+#include <rosflight/ros_logger.h>
 #include <yaml-cpp/yaml.h>
 
 #include <fstream>
@@ -409,5 +410,7 @@ void ParamManager<DerivedLogger>::param_set_timer_callback(const ros::TimerEvent
     param_set_queue_.pop_front();
   }
 }
+
+template class ParamManager<rosflight::ROSLogger>;
 
 } // namespace mavrosflight

--- a/rosflight/src/mavrosflight/param_manager.cpp
+++ b/rosflight/src/mavrosflight/param_manager.cpp
@@ -350,14 +350,14 @@ void ParamManager<DerivedLogger>::handle_command_ack_msg(const mavlink_message_t
       write_request_in_progress_ = false;
       if (ack.success == ROSFLIGHT_CMD_SUCCESS)
       {
-        ROS_INFO("Param write succeeded");
+        logger_.info("Param write succeeded");
         unsaved_changes_ = false;
 
         for (int i = 0; i < listeners_.size(); i++) listeners_[i]->on_params_saved_change(unsaved_changes_);
       }
       else
       {
-        ROS_INFO("Param write failed - maybe disarm the aricraft and try again?");
+        logger_.info("Param write failed - maybe disarm the aricraft and try again?");
         write_request_in_progress_ = false;
         unsaved_changes_ = true;
       }

--- a/rosflight/src/mavrosflight/param_manager.cpp
+++ b/rosflight/src/mavrosflight/param_manager.cpp
@@ -41,6 +41,7 @@
 #if defined(USE_ROS)
 #include <rosflight/ros_logger.h>
 #elif defined(STANDALONE)
+#include <rosflight/mavrosflight/default_logger.h>
 #include <rosflight/mavrosflight/logger_interface.h>
 #endif
 

--- a/rosflight/src/mavrosflight/param_manager.cpp
+++ b/rosflight/src/mavrosflight/param_manager.cpp
@@ -42,7 +42,8 @@
 
 namespace mavrosflight
 {
-ParamManager::ParamManager(MavlinkComm *const comm, LoggerInterface& logger) :
+template<typename DerivedLogger>
+ParamManager<DerivedLogger>::ParamManager(MavlinkComm *const comm, LoggerInterface<DerivedLogger>& logger) :
   comm_(comm),
   unsaved_changes_(false),
   write_request_in_progress_(false),
@@ -59,7 +60,8 @@ ParamManager::ParamManager(MavlinkComm *const comm, LoggerInterface& logger) :
                                      false /* not autostart */);
 }
 
-ParamManager::~ParamManager()
+template<typename DerivedLogger>
+ParamManager<DerivedLogger>::~ParamManager()
 {
   if (first_param_received_)
   {
@@ -67,7 +69,8 @@ ParamManager::~ParamManager()
   }
 }
 
-void ParamManager::handle_mavlink_message(const mavlink_message_t &msg)
+template<typename DerivedLogger>
+void ParamManager<DerivedLogger>::handle_mavlink_message(const mavlink_message_t &msg)
 {
   switch (msg.msgid)
   {
@@ -80,12 +83,14 @@ void ParamManager::handle_mavlink_message(const mavlink_message_t &msg)
   }
 }
 
-bool ParamManager::unsaved_changes()
+template<typename DerivedLogger>
+bool ParamManager<DerivedLogger>::unsaved_changes()
 {
   return unsaved_changes_;
 }
 
-bool ParamManager::get_param_value(std::string name, double *value)
+template<typename DerivedLogger>
+bool ParamManager<DerivedLogger>::get_param_value(std::string name, double *value)
 {
   if (is_param_id(name))
   {
@@ -99,7 +104,8 @@ bool ParamManager::get_param_value(std::string name, double *value)
   }
 }
 
-bool ParamManager::set_param_value(std::string name, double value)
+template<typename DerivedLogger>
+bool ParamManager<DerivedLogger>::set_param_value(std::string name, double value)
 {
   if (is_param_id(name))
   {
@@ -121,7 +127,8 @@ bool ParamManager::set_param_value(std::string name, double value)
   }
 }
 
-bool ParamManager::write_params()
+template<typename DerivedLogger>
+bool ParamManager<DerivedLogger>::write_params()
 {
   if (!write_request_in_progress_)
   {
@@ -140,7 +147,8 @@ bool ParamManager::write_params()
   }
 }
 
-void ParamManager::register_param_listener(ParamListenerInterface *listener)
+template<typename DerivedLogger>
+void ParamManager<DerivedLogger>::register_param_listener(ParamListenerInterface *listener)
 {
   if (listener == NULL)
     return;
@@ -159,7 +167,8 @@ void ParamManager::register_param_listener(ParamListenerInterface *listener)
     listeners_.push_back(listener);
 }
 
-void ParamManager::unregister_param_listener(ParamListenerInterface *listener)
+template<typename DerivedLogger>
+void ParamManager<DerivedLogger>::unregister_param_listener(ParamListenerInterface *listener)
 {
   if (listener == NULL)
     return;
@@ -174,7 +183,8 @@ void ParamManager::unregister_param_listener(ParamListenerInterface *listener)
   }
 }
 
-bool ParamManager::save_to_file(std::string filename)
+template<typename DerivedLogger>
+bool ParamManager<DerivedLogger>::save_to_file(std::string filename)
 {
   // build YAML document
   YAML::Emitter yaml;
@@ -207,7 +217,8 @@ bool ParamManager::save_to_file(std::string filename)
   return true;
 }
 
-bool ParamManager::load_from_file(std::string filename)
+template<typename DerivedLogger>
+bool ParamManager<DerivedLogger>::load_from_file(std::string filename)
 {
   try
   {
@@ -237,7 +248,8 @@ bool ParamManager::load_from_file(std::string filename)
   }
 }
 
-void ParamManager::request_params()
+template<typename DerivedLogger>
+void ParamManager<DerivedLogger>::request_params()
 {
   if (!first_param_received_)
   {
@@ -255,14 +267,16 @@ void ParamManager::request_params()
   }
 }
 
-void ParamManager::request_param_list()
+template<typename DerivedLogger>
+void ParamManager<DerivedLogger>::request_param_list()
 {
   mavlink_message_t param_list_msg;
   mavlink_msg_param_request_list_pack(1, 50, &param_list_msg, 1, MAV_COMP_ID_ALL);
   comm_->send_message(param_list_msg);
 }
 
-void ParamManager::request_param(int index)
+template<typename DerivedLogger>
+void ParamManager<DerivedLogger>::request_param(int index)
 {
   mavlink_message_t param_request_msg;
   char empty[MAVLINK_MSG_PARAM_VALUE_FIELD_PARAM_ID_LEN];
@@ -270,7 +284,8 @@ void ParamManager::request_param(int index)
   comm_->send_message(param_request_msg);
 }
 
-void ParamManager::handle_param_value_msg(const mavlink_message_t &msg)
+template<typename DerivedLogger>
+void ParamManager<DerivedLogger>::handle_param_value_msg(const mavlink_message_t &msg)
 {
   mavlink_param_value_t param;
   mavlink_msg_param_value_decode(&msg, &param);
@@ -321,7 +336,8 @@ void ParamManager::handle_param_value_msg(const mavlink_message_t &msg)
   }
 }
 
-void ParamManager::handle_command_ack_msg(const mavlink_message_t &msg)
+template<typename DerivedLogger>
+void ParamManager<DerivedLogger>::handle_command_ack_msg(const mavlink_message_t &msg)
 {
   if (write_request_in_progress_)
   {
@@ -348,12 +364,14 @@ void ParamManager::handle_command_ack_msg(const mavlink_message_t &msg)
   }
 }
 
-bool ParamManager::is_param_id(std::string name)
+template<typename DerivedLogger>
+bool ParamManager<DerivedLogger>::is_param_id(std::string name)
 {
   return (params_.find(name) != params_.end());
 }
 
-int ParamManager::get_num_params()
+template<typename DerivedLogger>
+int ParamManager<DerivedLogger>::get_num_params()
 {
   if (first_param_received_)
   {
@@ -365,17 +383,20 @@ int ParamManager::get_num_params()
   }
 }
 
-int ParamManager::get_params_received()
+template<typename DerivedLogger>
+int ParamManager<DerivedLogger>::get_params_received()
 {
   return received_count_;
 }
 
-bool ParamManager::got_all_params()
+template<typename DerivedLogger>
+bool ParamManager<DerivedLogger>::got_all_params()
 {
   return got_all_params_;
 }
 
-void ParamManager::param_set_timer_callback(const ros::TimerEvent &event)
+template<typename DerivedLogger>
+void ParamManager<DerivedLogger>::param_set_timer_callback(const ros::TimerEvent &event)
 {
   if (param_set_queue_.empty())
   {

--- a/rosflight/src/mavrosflight/param_manager.cpp
+++ b/rosflight/src/mavrosflight/param_manager.cpp
@@ -420,6 +420,8 @@ void ParamManager<DerivedLogger>::param_set_timer_callback(const ros::TimerEvent
 template class ParamManager<rosflight::ROSLogger>;
 #elif defined(STANDALONE)
 template class ParamManager<mavrosflight::DefaultLogger>;
+#else
+#error Unknown logging backend supplied for mavrosflight. Define USE_ROS or STANDALONE.
 #endif
 
 } // namespace mavrosflight

--- a/rosflight/src/mavrosflight/param_manager.cpp
+++ b/rosflight/src/mavrosflight/param_manager.cpp
@@ -48,8 +48,8 @@
 
 namespace mavrosflight
 {
-template<typename DerivedLogger>
-ParamManager<DerivedLogger>::ParamManager(MavlinkComm *const comm, LoggerInterface<DerivedLogger>& logger) :
+template <typename DerivedLogger>
+ParamManager<DerivedLogger>::ParamManager(MavlinkComm *const comm, LoggerInterface<DerivedLogger> &logger) :
   comm_(comm),
   unsaved_changes_(false),
   write_request_in_progress_(false),
@@ -66,7 +66,7 @@ ParamManager<DerivedLogger>::ParamManager(MavlinkComm *const comm, LoggerInterfa
                                      false /* not autostart */);
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 ParamManager<DerivedLogger>::~ParamManager()
 {
   if (first_param_received_)
@@ -75,7 +75,7 @@ ParamManager<DerivedLogger>::~ParamManager()
   }
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 void ParamManager<DerivedLogger>::handle_mavlink_message(const mavlink_message_t &msg)
 {
   switch (msg.msgid)
@@ -89,13 +89,13 @@ void ParamManager<DerivedLogger>::handle_mavlink_message(const mavlink_message_t
   }
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 bool ParamManager<DerivedLogger>::unsaved_changes()
 {
   return unsaved_changes_;
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 bool ParamManager<DerivedLogger>::get_param_value(std::string name, double *value)
 {
   if (is_param_id(name))
@@ -110,7 +110,7 @@ bool ParamManager<DerivedLogger>::get_param_value(std::string name, double *valu
   }
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 bool ParamManager<DerivedLogger>::set_param_value(std::string name, double value)
 {
   if (is_param_id(name))
@@ -133,7 +133,7 @@ bool ParamManager<DerivedLogger>::set_param_value(std::string name, double value
   }
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 bool ParamManager<DerivedLogger>::write_params()
 {
   if (!write_request_in_progress_)
@@ -153,7 +153,7 @@ bool ParamManager<DerivedLogger>::write_params()
   }
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 void ParamManager<DerivedLogger>::register_param_listener(ParamListenerInterface *listener)
 {
   if (listener == NULL)
@@ -173,7 +173,7 @@ void ParamManager<DerivedLogger>::register_param_listener(ParamListenerInterface
     listeners_.push_back(listener);
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 void ParamManager<DerivedLogger>::unregister_param_listener(ParamListenerInterface *listener)
 {
   if (listener == NULL)
@@ -189,7 +189,7 @@ void ParamManager<DerivedLogger>::unregister_param_listener(ParamListenerInterfa
   }
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 bool ParamManager<DerivedLogger>::save_to_file(std::string filename)
 {
   // build YAML document
@@ -223,7 +223,7 @@ bool ParamManager<DerivedLogger>::save_to_file(std::string filename)
   return true;
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 bool ParamManager<DerivedLogger>::load_from_file(std::string filename)
 {
   try
@@ -254,7 +254,7 @@ bool ParamManager<DerivedLogger>::load_from_file(std::string filename)
   }
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 void ParamManager<DerivedLogger>::request_params()
 {
   if (!first_param_received_)
@@ -273,7 +273,7 @@ void ParamManager<DerivedLogger>::request_params()
   }
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 void ParamManager<DerivedLogger>::request_param_list()
 {
   mavlink_message_t param_list_msg;
@@ -281,7 +281,7 @@ void ParamManager<DerivedLogger>::request_param_list()
   comm_->send_message(param_list_msg);
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 void ParamManager<DerivedLogger>::request_param(int index)
 {
   mavlink_message_t param_request_msg;
@@ -290,7 +290,7 @@ void ParamManager<DerivedLogger>::request_param(int index)
   comm_->send_message(param_request_msg);
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 void ParamManager<DerivedLogger>::handle_param_value_msg(const mavlink_message_t &msg)
 {
   mavlink_param_value_t param;
@@ -342,7 +342,7 @@ void ParamManager<DerivedLogger>::handle_param_value_msg(const mavlink_message_t
   }
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 void ParamManager<DerivedLogger>::handle_command_ack_msg(const mavlink_message_t &msg)
 {
   if (write_request_in_progress_)
@@ -370,13 +370,13 @@ void ParamManager<DerivedLogger>::handle_command_ack_msg(const mavlink_message_t
   }
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 bool ParamManager<DerivedLogger>::is_param_id(std::string name)
 {
   return (params_.find(name) != params_.end());
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 int ParamManager<DerivedLogger>::get_num_params()
 {
   if (first_param_received_)
@@ -389,19 +389,19 @@ int ParamManager<DerivedLogger>::get_num_params()
   }
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 int ParamManager<DerivedLogger>::get_params_received()
 {
   return received_count_;
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 bool ParamManager<DerivedLogger>::got_all_params()
 {
   return got_all_params_;
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 void ParamManager<DerivedLogger>::param_set_timer_callback(const ros::TimerEvent &event)
 {
   if (param_set_queue_.empty())

--- a/rosflight/src/mavrosflight/param_manager.cpp
+++ b/rosflight/src/mavrosflight/param_manager.cpp
@@ -40,6 +40,8 @@
 
 #if defined(USE_ROS)
 #include <rosflight/ros_logger.h>
+#elif defined(STANDALONE)
+#include <rosflight/mavrosflight/logger_interface.h>
 #endif
 
 #include <fstream>
@@ -416,6 +418,8 @@ void ParamManager<DerivedLogger>::param_set_timer_callback(const ros::TimerEvent
 
 #if defined(USE_ROS)
 template class ParamManager<rosflight::ROSLogger>;
+#elif defined(STANDALONE)
+template class ParamManager<mavrosflight::DefaultLogger>;
 #endif
 
 } // namespace mavrosflight

--- a/rosflight/src/mavrosflight/param_manager.cpp
+++ b/rosflight/src/mavrosflight/param_manager.cpp
@@ -35,15 +35,10 @@
  */
 
 #include <ros/ros.h>
+#include <rosflight/mavrosflight/logger_adapter.h>
+#include <rosflight/mavrosflight/logger_interface.h>
 #include <rosflight/mavrosflight/param_manager.h>
 #include <yaml-cpp/yaml.h>
-
-#if defined(USE_ROS)
-#include <rosflight/ros_logger.h>
-#elif defined(STANDALONE)
-#include <rosflight/mavrosflight/default_logger.h>
-#include <rosflight/mavrosflight/logger_interface.h>
-#endif
 
 #include <fstream>
 
@@ -417,10 +412,6 @@ void ParamManager<DerivedLogger>::param_set_timer_callback(const ros::TimerEvent
   }
 }
 
-#if defined(USE_ROS)
-template class ParamManager<rosflight::ROSLogger>;
-#elif defined(STANDALONE)
-template class ParamManager<mavrosflight::DefaultLogger>;
-#endif
+template class ParamManager<DerivedLoggerType>;
 
 } // namespace mavrosflight

--- a/rosflight/src/mavrosflight/param_manager.cpp
+++ b/rosflight/src/mavrosflight/param_manager.cpp
@@ -42,14 +42,15 @@
 
 namespace mavrosflight
 {
-ParamManager::ParamManager(MavlinkComm *const comm) :
+ParamManager::ParamManager(MavlinkComm *const comm, LoggerInterface& logger) :
   comm_(comm),
   unsaved_changes_(false),
   write_request_in_progress_(false),
   first_param_received_(false),
   received_count_(0),
   got_all_params_(false),
-  param_set_in_progress_(false)
+  param_set_in_progress_(false),
+  logger_(logger)
 {
   comm_->register_mavlink_listener(this);
 

--- a/rosflight/src/mavrosflight/param_manager.cpp
+++ b/rosflight/src/mavrosflight/param_manager.cpp
@@ -420,8 +420,6 @@ void ParamManager<DerivedLogger>::param_set_timer_callback(const ros::TimerEvent
 template class ParamManager<rosflight::ROSLogger>;
 #elif defined(STANDALONE)
 template class ParamManager<mavrosflight::DefaultLogger>;
-#else
-#error Unknown logging backend supplied for mavrosflight. Define USE_ROS or STANDALONE.
 #endif
 
 } // namespace mavrosflight

--- a/rosflight/src/mavrosflight/time_manager.cpp
+++ b/rosflight/src/mavrosflight/time_manager.cpp
@@ -38,6 +38,8 @@
 
 #if defined(USE_ROS)
 #include <rosflight/ros_logger.h>
+#elif defined(STANDALONE)
+#include <rosflight/mavrosflight/logger_interface.h>
 #endif
 
 namespace mavrosflight
@@ -137,6 +139,8 @@ void TimeManager<DerivedLogger>::timer_callback(const ros::TimerEvent &event)
 
 #if defined(USE_ROS)
 template class TimeManager<rosflight::ROSLogger>;
+#elif defined(STANDALONE)
+template class TimeManager<mavrosflight::DefaultLogger>;
 #endif
 
 } // namespace mavrosflight

--- a/rosflight/src/mavrosflight/time_manager.cpp
+++ b/rosflight/src/mavrosflight/time_manager.cpp
@@ -72,8 +72,8 @@ void TimeManager<DerivedLogger>::handle_mavlink_message(const mavlink_message_t 
       if (!initialized_ || std::abs(offset_ns_ - offset_ns) > 1e7) // if difference > 10ms, use it directly
       {
         offset_ns_ = offset_ns;
-        ROS_INFO("Detected time offset of %0.3f s.", offset_ns / 1e9);
-        ROS_DEBUG("FCU time: %0.3f, System time: %0.3f", tsync.tc1 * 1e-9, tsync.ts1 * 1e-9);
+        logger_.info("Detected time offset of %0.3f s.", offset_ns / 1e9);
+        logger_.debug("FCU time: %0.3f, System time: %0.3f", tsync.tc1 * 1e-9, tsync.ts1 * 1e-9);
         initialized_ = true;
       }
       else // otherwise low-pass filter the offset
@@ -95,7 +95,7 @@ ros::Time TimeManager<DerivedLogger>::get_ros_time_ms(uint32_t boot_ms)
   int64_t ns = boot_ns + offset_ns_;
   if (ns < 0)
   {
-    ROS_ERROR_THROTTLE(1, "negative time calculated from FCU: boot_ns=%ld, offset_ns=%ld.  Using system time", boot_ns,
+    logger_.error_throttle(1, "negative time calculated from FCU: boot_ns=%ld, offset_ns=%ld.  Using system time", boot_ns,
                        offset_ns_);
     return ros::Time::now();
   }
@@ -115,7 +115,7 @@ ros::Time TimeManager<DerivedLogger>::get_ros_time_us(uint64_t boot_us)
   int64_t ns = boot_ns + offset_ns_;
   if (ns < 0)
   {
-    ROS_ERROR_THROTTLE(1, "negative time calculated from FCU: boot_ns=%ld, offset_ns=%ld.  Using system time", boot_ns,
+    logger_.error_throttle(1, "negative time calculated from FCU: boot_ns=%ld, offset_ns=%ld.  Using system time", boot_ns,
                        offset_ns_);
     return ros::Time::now();
   }

--- a/rosflight/src/mavrosflight/time_manager.cpp
+++ b/rosflight/src/mavrosflight/time_manager.cpp
@@ -38,12 +38,14 @@
 
 namespace mavrosflight
 {
-TimeManager::TimeManager(MavlinkComm *comm) :
+TimeManager::TimeManager(MavlinkComm *comm, LoggerInterface& logger) :
   comm_(comm),
   offset_alpha_(0.95),
   offset_ns_(0),
   offset_(0.0),
-  initialized_(false)
+  initialized_(false),
+  logger_(logger)
+
 {
   comm_->register_mavlink_listener(this);
 

--- a/rosflight/src/mavrosflight/time_manager.cpp
+++ b/rosflight/src/mavrosflight/time_manager.cpp
@@ -141,6 +141,8 @@ void TimeManager<DerivedLogger>::timer_callback(const ros::TimerEvent &event)
 template class TimeManager<rosflight::ROSLogger>;
 #elif defined(STANDALONE)
 template class TimeManager<mavrosflight::DefaultLogger>;
+#else
+#error Unknown logging backend supplied for mavrosflight. Define USE_ROS or STANDALONE.
 #endif
 
 } // namespace mavrosflight

--- a/rosflight/src/mavrosflight/time_manager.cpp
+++ b/rosflight/src/mavrosflight/time_manager.cpp
@@ -35,7 +35,10 @@
  */
 
 #include <rosflight/mavrosflight/time_manager.h>
+
+#if defined(USE_ROS)
 #include <rosflight/ros_logger.h>
+#endif
 
 namespace mavrosflight
 {
@@ -132,6 +135,8 @@ void TimeManager<DerivedLogger>::timer_callback(const ros::TimerEvent &event)
   comm_->send_message(msg);
 }
 
+#if defined(USE_ROS)
 template class TimeManager<rosflight::ROSLogger>;
+#endif
 
 } // namespace mavrosflight

--- a/rosflight/src/mavrosflight/time_manager.cpp
+++ b/rosflight/src/mavrosflight/time_manager.cpp
@@ -34,14 +34,9 @@
  * \author Daniel Koch <daniel.koch@byu.edu>
  */
 
-#include <rosflight/mavrosflight/time_manager.h>
-
-#if defined(USE_ROS)
-#include <rosflight/ros_logger.h>
-#elif defined(STANDALONE)
-#include <rosflight/mavrosflight/default_logger.h>
+#include <rosflight/mavrosflight/logger_adapter.h>
 #include <rosflight/mavrosflight/logger_interface.h>
-#endif
+#include <rosflight/mavrosflight/time_manager.h>
 
 namespace mavrosflight
 {
@@ -138,10 +133,6 @@ void TimeManager<DerivedLogger>::timer_callback(const ros::TimerEvent &event)
   comm_->send_message(msg);
 }
 
-#if defined(USE_ROS)
-template class TimeManager<rosflight::ROSLogger>;
-#elif defined(STANDALONE)
-template class TimeManager<mavrosflight::DefaultLogger>;
-#endif
+template class TimeManager<DerivedLoggerType>;
 
 } // namespace mavrosflight

--- a/rosflight/src/mavrosflight/time_manager.cpp
+++ b/rosflight/src/mavrosflight/time_manager.cpp
@@ -44,8 +44,8 @@
 
 namespace mavrosflight
 {
-template<typename DerivedLogger>
-TimeManager<DerivedLogger>::TimeManager(MavlinkComm *comm, LoggerInterface<DerivedLogger>& logger) :
+template <typename DerivedLogger>
+TimeManager<DerivedLogger>::TimeManager(MavlinkComm *comm, LoggerInterface<DerivedLogger> &logger) :
   comm_(comm),
   offset_alpha_(0.95),
   offset_ns_(0),
@@ -60,7 +60,7 @@ TimeManager<DerivedLogger>::TimeManager(MavlinkComm *comm, LoggerInterface<Deriv
   time_sync_timer_ = nh.createTimer(ros::Duration(ros::Rate(10)), &TimeManager::timer_callback, this);
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 void TimeManager<DerivedLogger>::handle_mavlink_message(const mavlink_message_t &msg)
 {
   int64_t now_ns = ros::Time::now().toNSec();
@@ -89,7 +89,7 @@ void TimeManager<DerivedLogger>::handle_mavlink_message(const mavlink_message_t 
   }
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 ros::Time TimeManager<DerivedLogger>::get_ros_time_ms(uint32_t boot_ms)
 {
   if (!initialized_)
@@ -100,8 +100,8 @@ ros::Time TimeManager<DerivedLogger>::get_ros_time_ms(uint32_t boot_ms)
   int64_t ns = boot_ns + offset_ns_;
   if (ns < 0)
   {
-    logger_.error_throttle(1, "negative time calculated from FCU: boot_ns=%ld, offset_ns=%ld.  Using system time", boot_ns,
-                       offset_ns_);
+    logger_.error_throttle(1, "negative time calculated from FCU: boot_ns=%ld, offset_ns=%ld.  Using system time",
+                           boot_ns, offset_ns_);
     return ros::Time::now();
   }
   ros::Time now;
@@ -109,7 +109,7 @@ ros::Time TimeManager<DerivedLogger>::get_ros_time_ms(uint32_t boot_ms)
   return now;
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 ros::Time TimeManager<DerivedLogger>::get_ros_time_us(uint64_t boot_us)
 {
   if (!initialized_)
@@ -120,8 +120,8 @@ ros::Time TimeManager<DerivedLogger>::get_ros_time_us(uint64_t boot_us)
   int64_t ns = boot_ns + offset_ns_;
   if (ns < 0)
   {
-    logger_.error_throttle(1, "negative time calculated from FCU: boot_ns=%ld, offset_ns=%ld.  Using system time", boot_ns,
-                       offset_ns_);
+    logger_.error_throttle(1, "negative time calculated from FCU: boot_ns=%ld, offset_ns=%ld.  Using system time",
+                           boot_ns, offset_ns_);
     return ros::Time::now();
   }
   ros::Time now;
@@ -129,7 +129,7 @@ ros::Time TimeManager<DerivedLogger>::get_ros_time_us(uint64_t boot_us)
   return now;
 }
 
-template<typename DerivedLogger>
+template <typename DerivedLogger>
 void TimeManager<DerivedLogger>::timer_callback(const ros::TimerEvent &event)
 {
   mavlink_message_t msg;

--- a/rosflight/src/mavrosflight/time_manager.cpp
+++ b/rosflight/src/mavrosflight/time_manager.cpp
@@ -38,7 +38,8 @@
 
 namespace mavrosflight
 {
-TimeManager::TimeManager(MavlinkComm *comm, LoggerInterface& logger) :
+template<typename DerivedLogger>
+TimeManager<DerivedLogger>::TimeManager(MavlinkComm *comm, LoggerInterface<DerivedLogger>& logger) :
   comm_(comm),
   offset_alpha_(0.95),
   offset_ns_(0),
@@ -53,7 +54,8 @@ TimeManager::TimeManager(MavlinkComm *comm, LoggerInterface& logger) :
   time_sync_timer_ = nh.createTimer(ros::Duration(ros::Rate(10)), &TimeManager::timer_callback, this);
 }
 
-void TimeManager::handle_mavlink_message(const mavlink_message_t &msg)
+template<typename DerivedLogger>
+void TimeManager<DerivedLogger>::handle_mavlink_message(const mavlink_message_t &msg)
 {
   int64_t now_ns = ros::Time::now().toNSec();
 
@@ -81,7 +83,8 @@ void TimeManager::handle_mavlink_message(const mavlink_message_t &msg)
   }
 }
 
-ros::Time TimeManager::get_ros_time_ms(uint32_t boot_ms)
+template<typename DerivedLogger>
+ros::Time TimeManager<DerivedLogger>::get_ros_time_ms(uint32_t boot_ms)
 {
   if (!initialized_)
     return ros::Time::now();
@@ -100,7 +103,8 @@ ros::Time TimeManager::get_ros_time_ms(uint32_t boot_ms)
   return now;
 }
 
-ros::Time TimeManager::get_ros_time_us(uint64_t boot_us)
+template<typename DerivedLogger>
+ros::Time TimeManager<DerivedLogger>::get_ros_time_us(uint64_t boot_us)
 {
   if (!initialized_)
     return ros::Time::now();
@@ -119,7 +123,8 @@ ros::Time TimeManager::get_ros_time_us(uint64_t boot_us)
   return now;
 }
 
-void TimeManager::timer_callback(const ros::TimerEvent &event)
+template<typename DerivedLogger>
+void TimeManager<DerivedLogger>::timer_callback(const ros::TimerEvent &event)
 {
   mavlink_message_t msg;
   mavlink_msg_timesync_pack(1, 50, &msg, 0, ros::Time::now().toNSec());

--- a/rosflight/src/mavrosflight/time_manager.cpp
+++ b/rosflight/src/mavrosflight/time_manager.cpp
@@ -141,8 +141,6 @@ void TimeManager<DerivedLogger>::timer_callback(const ros::TimerEvent &event)
 template class TimeManager<rosflight::ROSLogger>;
 #elif defined(STANDALONE)
 template class TimeManager<mavrosflight::DefaultLogger>;
-#else
-#error Unknown logging backend supplied for mavrosflight. Define USE_ROS or STANDALONE.
 #endif
 
 } // namespace mavrosflight

--- a/rosflight/src/mavrosflight/time_manager.cpp
+++ b/rosflight/src/mavrosflight/time_manager.cpp
@@ -39,6 +39,7 @@
 #if defined(USE_ROS)
 #include <rosflight/ros_logger.h>
 #elif defined(STANDALONE)
+#include <rosflight/mavrosflight/default_logger.h>
 #include <rosflight/mavrosflight/logger_interface.h>
 #endif
 

--- a/rosflight/src/mavrosflight/time_manager.cpp
+++ b/rosflight/src/mavrosflight/time_manager.cpp
@@ -35,6 +35,7 @@
  */
 
 #include <rosflight/mavrosflight/time_manager.h>
+#include <rosflight/ros_logger.h>
 
 namespace mavrosflight
 {
@@ -130,5 +131,7 @@ void TimeManager<DerivedLogger>::timer_callback(const ros::TimerEvent &event)
   mavlink_msg_timesync_pack(1, 50, &msg, 0, ros::Time::now().toNSec());
   comm_->send_message(msg);
 }
+
+template class TimeManager<rosflight::ROSLogger>;
 
 } // namespace mavrosflight

--- a/rosflight/src/rosflight_io.cpp
+++ b/rosflight/src/rosflight_io.cpp
@@ -39,6 +39,7 @@
 #define GIT_VERSION_STRING TOSTRING(ROSFLIGHT_VERSION)
 #endif
 
+#include <rosflight/ros_logger.h>
 #include <rosflight/mavrosflight/mavlink_serial.h>
 #include <rosflight/mavrosflight/mavlink_udp.h>
 #include <rosflight/mavrosflight/serial_exception.h>
@@ -101,7 +102,8 @@ rosflightIO::rosflightIO()
   try
   {
     mavlink_comm_->open(); //! \todo move this into the MavROSflight constructor
-    mavrosflight_ = new mavrosflight::MavROSflight(*mavlink_comm_);
+    rosflight::ROSLogger logger;
+    mavrosflight_ = new mavrosflight::MavROSflight<rosflight::ROSLogger>(*mavlink_comm_, logger);
   }
   catch (mavrosflight::SerialException e)
   {

--- a/rosflight/src/rosflight_io.cpp
+++ b/rosflight/src/rosflight_io.cpp
@@ -39,10 +39,10 @@
 #define GIT_VERSION_STRING TOSTRING(ROSFLIGHT_VERSION)
 #endif
 
-#include <rosflight/ros_logger.h>
 #include <rosflight/mavrosflight/mavlink_serial.h>
 #include <rosflight/mavrosflight/mavlink_udp.h>
 #include <rosflight/mavrosflight/serial_exception.h>
+#include <rosflight/ros_logger.h>
 #include <tf/tf.h>
 #include <cstdint>
 #include <eigen3/Eigen/Core>


### PR DESCRIPTION
Part of #131.
Abstract the use of ROS loggers out of mavrosflight. 

Because you need to declare the type of a template class in the file where it is implemented, I added the USE_ROS and STANDALONE compiler macros which are checked in `mavrosflight.cpp`, `time_manager.cpp`, and `param_manager.cpp`. Not sure if this is the cleanest/best option.

Currently there is a `warning: format not a string literal and no format arguments` when this is built. This is because we are passing the format string into the logger as a variable. I think typically the compiler can trace `const char*` and figure out if there is an issue, but I think there is something in what I am doing that makes it unable to track down the use of the format string. If you have any suggestions on how to get rid of that warning, that'd be great.