### PR TITLE
Mavrosflight timer abstraction

### DIFF
--- a/rosflight/include/rosflight/mavrosflight/interface_adapter.h
+++ b/rosflight/include/rosflight/mavrosflight/interface_adapter.h
@@ -31,7 +31,7 @@
  */
 
 /**
- * @file logger_interface.h
+ * @file interface_adapter.h
  * @author Jacob Willis <jbwillis272@gmail.com>
  */
 

--- a/rosflight/include/rosflight/mavrosflight/mavrosflight.h
+++ b/rosflight/include/rosflight/mavrosflight/mavrosflight.h
@@ -53,7 +53,7 @@
 
 namespace mavrosflight
 {
-template <typename DerivedLogger>
+template <typename DerivedLogger, typename DerivedTimerInterface>
 class MavROSflight
 {
 public:
@@ -65,6 +65,7 @@ public:
   MavROSflight(MavlinkComm& mavlink_comm,
                LoggerInterface<DerivedLogger>& logger,
                TimeInterface& time_interface,
+               TimerInterface<DerivedTimerInterface>& timer_interface,
                uint8_t sysid = 1,
                uint8_t compid = 50);
 
@@ -76,7 +77,7 @@ public:
   // public member objects
   MavlinkComm& comm;
   ParamManager<DerivedLogger> param;
-  TimeManager<DerivedLogger> time;
+  TimeManager<DerivedLogger, DerivedTimerInterface> time;
 
 private:
   // member variables

--- a/rosflight/include/rosflight/mavrosflight/mavrosflight.h
+++ b/rosflight/include/rosflight/mavrosflight/mavrosflight.h
@@ -64,6 +64,7 @@ public:
    */
   MavROSflight(MavlinkComm& mavlink_comm,
                LoggerInterface<DerivedLogger>& logger,
+               TimeInterface& time_intf,
                uint8_t sysid = 1,
                uint8_t compid = 50);
 

--- a/rosflight/include/rosflight/mavrosflight/mavrosflight.h
+++ b/rosflight/include/rosflight/mavrosflight/mavrosflight.h
@@ -64,7 +64,7 @@ public:
    */
   MavROSflight(MavlinkComm& mavlink_comm,
                LoggerInterface<DerivedLogger>& logger,
-               TimeInterface& time_intf,
+               TimeInterface& time_interface,
                uint8_t sysid = 1,
                uint8_t compid = 50);
 

--- a/rosflight/include/rosflight/mavrosflight/time_interface.h
+++ b/rosflight/include/rosflight/mavrosflight/time_interface.h
@@ -1,0 +1,59 @@
+/*
+ * Software License Agreement (BSD-3 License)
+ *
+ * Copyright (c) 2020 Jacob Willis.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file time_interface.h
+ * @author Jacob Willis <jbwillis272@gmail.com>
+ */
+
+#ifndef MAVROSFLIGHT_TIME_INTERFACE_H
+#define MAVROSFLIGHT_TIME_INTERFACE_H
+
+#include <cstdint>
+
+namespace mavrosflight
+{
+typedef uint64_t time_ns_t;
+/**
+ * \class TimeInterface
+ * \brief Interface for acquiring system time
+ *
+ * For simplicity, times are int64_t, in nanoseconds.
+ */
+class TimeInterface
+{
+public:
+  virtual time_ns_t now_ns() = 0;
+};
+
+} // namespace mavrosflight
+#endif /* MAVROSFLIGHT_TIME_INTERFACE_H */

--- a/rosflight/include/rosflight/mavrosflight/time_manager.h
+++ b/rosflight/include/rosflight/mavrosflight/time_manager.h
@@ -74,7 +74,7 @@ private:
   bool initialized_;
 
   LoggerInterface<DerivedLogger> &logger_;
-  TimeInterface &time_intf_;
+  TimeInterface &time_interface_;
 };
 
 } // namespace mavrosflight

--- a/rosflight/include/rosflight/mavrosflight/time_manager.h
+++ b/rosflight/include/rosflight/mavrosflight/time_manager.h
@@ -50,11 +50,14 @@
 
 namespace mavrosflight
 {
-template <typename DerivedLogger>
+template <typename DerivedLogger, typename DerivedTimerInterface>
 class TimeManager : MavlinkListenerInterface
 {
 public:
-  TimeManager(MavlinkComm *comm, LoggerInterface<DerivedLogger> &logger, TimeInterface &time);
+  TimeManager(MavlinkComm *comm, 
+              LoggerInterface<DerivedLogger> &logger,
+              TimeInterface &time_intf,
+              TimerInterface<DerivedTimerInterface> &timer_interface);
 
   virtual void handle_mavlink_message(const mavlink_message_t &msg);
 
@@ -64,8 +67,8 @@ public:
 private:
   MavlinkComm *comm_;
 
-  ros::Timer time_sync_timer_;
-  void timer_callback(const ros::TimerEvent &event);
+  AbstractTimer* time_sync_timer_;
+  void timer_callback();
 
   double offset_alpha_;
   int64_t offset_ns_;
@@ -75,6 +78,7 @@ private:
 
   LoggerInterface<DerivedLogger> &logger_;
   TimeInterface &time_interface_;
+  TimerInterface<DerivedTimerInterface> &timer_interface_;
 };
 
 } // namespace mavrosflight

--- a/rosflight/include/rosflight/mavrosflight/time_manager.h
+++ b/rosflight/include/rosflight/mavrosflight/time_manager.h
@@ -41,6 +41,7 @@
 #include <rosflight/mavrosflight/mavlink_bridge.h>
 #include <rosflight/mavrosflight/mavlink_comm.h>
 #include <rosflight/mavrosflight/mavlink_listener_interface.h>
+#include <rosflight/mavrosflight/time_interface.h>
 
 #include <ros/ros.h>
 
@@ -53,12 +54,12 @@ template <typename DerivedLogger>
 class TimeManager : MavlinkListenerInterface
 {
 public:
-  TimeManager(MavlinkComm *comm, LoggerInterface<DerivedLogger> &logger);
+  TimeManager(MavlinkComm *comm, LoggerInterface<DerivedLogger> &logger, TimeInterface &time);
 
   virtual void handle_mavlink_message(const mavlink_message_t &msg);
 
-  ros::Time get_ros_time_ms(uint32_t boot_ms);
-  ros::Time get_ros_time_us(uint64_t boot_us);
+  time_ns_t get_time_boot_ms(uint32_t boot_ms);
+  time_ns_t get_time_boot_us(uint64_t boot_us);
 
 private:
   MavlinkComm *comm_;
@@ -73,6 +74,7 @@ private:
   bool initialized_;
 
   LoggerInterface<DerivedLogger> &logger_;
+  TimeInterface &time_intf_;
 };
 
 } // namespace mavrosflight

--- a/rosflight/include/rosflight/mavrosflight/timer_interface.h
+++ b/rosflight/include/rosflight/mavrosflight/timer_interface.h
@@ -31,29 +31,49 @@
  */
 
 /**
- * @file interface_adapter.h
+ * @file timer_interface.h
  * @author Jacob Willis <jbwillis272@gmail.com>
  */
 
-#ifndef MAVROSFLIGHT_LOGGER_ADAPTER_H
-#define MAVROSFLIGHT_LOGGER_ADAPTER_H
+#ifndef MAVROSFLIGHT_TIMER_INTERFACE_H
+#define MAVROSFLIGHT_TIMER_INTERFACE_H
 
-#if defined(USE_ROS)
-#include <rosflight/ros_logger.h>
-#include <rosflight/ros_timer.h>
+#include <cstdint>
+
 namespace mavrosflight
 {
-using DerivedLoggerType = rosflight::ROSLogger;
-using DerivedTimerInterfaceType = rosflight::ROSTimerInterface;
-}
-#elif defined(STANDALONE)
-#include <rosflight/mavrosflight/default_logger.h>
-namespace mavrosflight
+/**
+ * \class AbstractTimer
+ * \brief Abstracts basic timer functionality
+ *
+ */
+class AbstractTimer
 {
-using DerivedLoggerType = mavrosflight::DefaultLogger;
-}
-#else
-#error "Unknown logging backend supplied for mavrosflight. Define USE_ROS or STANDALONE."
-#endif
+public:
+  virtual void start() = 0;
+  virtual void stop() = 0;
+};
 
-#endif // MAVROSFLIGHT_LOGGER_ADAPTER_H
+/**
+ * \class TimerInterface
+ * \brief Provide an interface for creating timers
+ *
+ */
+template <typename Derived>
+class TimerInterface
+{
+public:
+  template <class T>
+  AbstractTimer* createTimer(uint32_t rate_hz,
+                             void (T::*callback)(),
+                             T* obj,
+                             bool oneshot = false,
+                             bool autostart = true)
+  {
+    Derived& derived = static_cast<Derived&>(*this);
+    derived.createTimer(rate_hz, callback, obj, oneshot, autostart);
+  }
+};
+
+} // namespace mavrosflight
+#endif /* MAVROSFLIGHT_TIMER_INTERFACE_H */

--- a/rosflight/include/rosflight/ros_time.h
+++ b/rosflight/include/rosflight/ros_time.h
@@ -1,0 +1,55 @@
+/*
+ * Software License Agreement (BSD-3 License)
+ *
+ * Copyright (c) 2020 Jacob Willis.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file ros_time.h
+ * @author Jacob Willis <jbwillis272@gmail.com>
+ */
+
+#ifndef ROSFLIGHT_ROS_TIME_H
+#define ROSFLIGHT_ROS_TIME_H
+
+#include <rosflight/mavrosflight/time_interface.h>
+
+#include <ros/ros.h>
+
+namespace rosflight
+{
+class ROSTime : public mavrosflight::TimeInterface
+{
+public:
+  inline mavrosflight::time_ns_t now_ns() { return ros::Time::now().toNSec(); }
+};
+
+} // namespace rosflight
+
+#endif /* ROSFLIGHT_ROS_TIMER_H */

--- a/rosflight/src/mavrosflight/mavrosflight.cpp
+++ b/rosflight/src/mavrosflight/mavrosflight.cpp
@@ -42,15 +42,17 @@ namespace mavrosflight
 {
 using boost::asio::serial_port_base;
 
-template <typename DerivedLogger>
-MavROSflight<DerivedLogger>::MavROSflight(MavlinkComm &mavlink_comm,
-                                          LoggerInterface<DerivedLogger> &logger,
-                                          TimeInterface &time_interface,
-                                          uint8_t sysid /* = 1 */,
-                                          uint8_t compid /* = 50 */) :
+template <typename DerivedLogger, typename DerivedTimerInterface>
+MavROSflight<DerivedLogger, DerivedTimerInterface>::MavROSflight(
+  MavlinkComm &mavlink_comm,
+  LoggerInterface<DerivedLogger> &logger,
+  TimeInterface &time_interface,
+  TimerInterface<DerivedTimerInterface>& timer_interface,
+  uint8_t sysid /* = 1 */,
+  uint8_t compid /* = 50 */) :
   comm(mavlink_comm),
   param(&comm, logger),
-  time(&comm, logger, time_interface),
+  time(&comm, logger, time_interface, timer_interface),
   sysid_(sysid),
   compid_(compid)
 {
@@ -58,12 +60,12 @@ MavROSflight<DerivedLogger>::MavROSflight(MavlinkComm &mavlink_comm,
   // comm.open();
 }
 
-template <typename DerivedLogger>
-MavROSflight<DerivedLogger>::~MavROSflight()
+template <typename DerivedLogger, typename DerivedTimerInterface>
+MavROSflight<DerivedLogger, DerivedTimerInterface>::~MavROSflight()
 {
   comm.close();
 }
 
-template class MavROSflight<DerivedLoggerType>;
+template class MavROSflight<DerivedLoggerType, DerivedTimerInterfaceType>;
 
 } // namespace mavrosflight

--- a/rosflight/src/mavrosflight/mavrosflight.cpp
+++ b/rosflight/src/mavrosflight/mavrosflight.cpp
@@ -38,8 +38,6 @@
 #include <rosflight/mavrosflight/logger_interface.h>
 #include <rosflight/mavrosflight/mavrosflight.h>
 
-#include <ros/ros.h>
-
 namespace mavrosflight
 {
 using boost::asio::serial_port_base;
@@ -47,11 +45,12 @@ using boost::asio::serial_port_base;
 template <typename DerivedLogger>
 MavROSflight<DerivedLogger>::MavROSflight(MavlinkComm &mavlink_comm,
                                           LoggerInterface<DerivedLogger> &logger,
+                                          TimeInterface &time_intf,
                                           uint8_t sysid /* = 1 */,
                                           uint8_t compid /* = 50 */) :
   comm(mavlink_comm),
   param(&comm, logger),
-  time(&comm, logger),
+  time(&comm, logger, time_intf),
   sysid_(sysid),
   compid_(compid)
 {

--- a/rosflight/src/mavrosflight/mavrosflight.cpp
+++ b/rosflight/src/mavrosflight/mavrosflight.cpp
@@ -45,12 +45,12 @@ using boost::asio::serial_port_base;
 template <typename DerivedLogger>
 MavROSflight<DerivedLogger>::MavROSflight(MavlinkComm &mavlink_comm,
                                           LoggerInterface<DerivedLogger> &logger,
-                                          TimeInterface &time_intf,
+                                          TimeInterface &time_interface,
                                           uint8_t sysid /* = 1 */,
                                           uint8_t compid /* = 50 */) :
   comm(mavlink_comm),
   param(&comm, logger),
-  time(&comm, logger, time_intf),
+  time(&comm, logger, time_interface),
   sysid_(sysid),
   compid_(compid)
 {

--- a/rosflight/src/mavrosflight/mavrosflight.cpp
+++ b/rosflight/src/mavrosflight/mavrosflight.cpp
@@ -34,7 +34,7 @@
  * \author Daniel Koch <daniel.koch@byu.edu>
  */
 
-#include <rosflight/mavrosflight/logger_adapter.h>
+#include <rosflight/mavrosflight/interface_adapter.h>
 #include <rosflight/mavrosflight/logger_interface.h>
 #include <rosflight/mavrosflight/mavrosflight.h>
 

--- a/rosflight/src/mavrosflight/param_manager.cpp
+++ b/rosflight/src/mavrosflight/param_manager.cpp
@@ -35,7 +35,7 @@
  */
 
 #include <ros/ros.h>
-#include <rosflight/mavrosflight/logger_adapter.h>
+#include <rosflight/mavrosflight/interface_adapter.h>
 #include <rosflight/mavrosflight/logger_interface.h>
 #include <rosflight/mavrosflight/param_manager.h>
 #include <yaml-cpp/yaml.h>

--- a/rosflight/src/mavrosflight/time_manager.cpp
+++ b/rosflight/src/mavrosflight/time_manager.cpp
@@ -34,7 +34,7 @@
  * \author Daniel Koch <daniel.koch@byu.edu>
  */
 
-#include <rosflight/mavrosflight/logger_adapter.h>
+#include <rosflight/mavrosflight/interface_adapter.h>
 #include <rosflight/mavrosflight/logger_interface.h>
 #include <rosflight/mavrosflight/time_interface.h>
 #include <rosflight/mavrosflight/time_manager.h>

--- a/rosflight/src/mavrosflight/time_manager.cpp
+++ b/rosflight/src/mavrosflight/time_manager.cpp
@@ -44,14 +44,14 @@ namespace mavrosflight
 template <typename DerivedLogger>
 TimeManager<DerivedLogger>::TimeManager(MavlinkComm *comm,
                                         LoggerInterface<DerivedLogger> &logger,
-                                        TimeInterface &time_intf) :
+                                        TimeInterface &time_interface) :
   comm_(comm),
   offset_alpha_(0.95),
   offset_ns_(0),
   offset_(0.0),
   initialized_(false),
   logger_(logger),
-  time_intf_(time_intf)
+  time_interface_(time_interface)
 
 {
   comm_->register_mavlink_listener(this);
@@ -93,7 +93,7 @@ template <typename DerivedLogger>
 time_ns_t TimeManager<DerivedLogger>::get_time_boot_ms(uint32_t boot_ms)
 {
   if (!initialized_)
-    return time_intf_.now_ns();
+    return time_interface_.now_ns();
 
   int64_t boot_ns = (int64_t)boot_ms * 1000000;
 
@@ -102,7 +102,7 @@ time_ns_t TimeManager<DerivedLogger>::get_time_boot_ms(uint32_t boot_ms)
   {
     logger_.error_throttle(1, "negative time calculated from FCU: boot_ns=%ld, offset_ns=%ld.  Using system time",
                            boot_ns, offset_ns_);
-    return time_intf_.now_ns();
+    return time_interface_.now_ns();
   }
   return (time_ns_t)ns;
 }
@@ -111,7 +111,7 @@ template <typename DerivedLogger>
 time_ns_t TimeManager<DerivedLogger>::get_time_boot_us(uint64_t boot_us)
 {
   if (!initialized_)
-    return time_intf_.now_ns();
+    return time_interface_.now_ns();
 
   int64_t boot_ns = (int64_t)boot_us * 1000;
 
@@ -120,7 +120,7 @@ time_ns_t TimeManager<DerivedLogger>::get_time_boot_us(uint64_t boot_us)
   {
     logger_.error_throttle(1, "negative time calculated from FCU: boot_ns=%ld, offset_ns=%ld.  Using system time",
                            boot_ns, offset_ns_);
-    return time_intf_.now_ns();
+    return time_interface_.now_ns();
   }
   return (time_ns_t)ns;
 }

--- a/rosflight/src/rosflight_io.cpp
+++ b/rosflight/src/rosflight_io.cpp
@@ -104,8 +104,8 @@ rosflightIO::rosflightIO()
   {
     mavlink_comm_->open(); //! \todo move this into the MavROSflight constructor
     rosflight::ROSLogger logger;
-    rosflight::ROSTime time_intf;
-    mavrosflight_ = new mavrosflight::MavROSflight<rosflight::ROSLogger>(*mavlink_comm_, logger, time_intf);
+    rosflight::ROSTime time_interface;
+    mavrosflight_ = new mavrosflight::MavROSflight<rosflight::ROSLogger>(*mavlink_comm_, logger, time_interface);
   }
   catch (mavrosflight::SerialException e)
   {


### PR DESCRIPTION
The two most relevant files to look at to get an idea of what I am doing are `timer_interface.h` and `ros_timer.h` .
Essentially I have a base class `AbstractTimer` which simply provides an interface to start and stop functions. Then, there is another base class `TimerInterface` with a `createTimer` function which returns an `AbstractTimer`. It uses CRTP to pass down the `createTimer` to its inherited `ROSTimerInterface` class. Since the `ROSTimerInterface` class is created in `rosflight_io`, it has to be able to handle the creation of multiple timers, so it calls new and keeps track of the timers in a vector.

I am really not convinced this is a correct or best way to approach this, but it's my best shot at it. I may be missing something fundamental that would make this all come together easily. If you can provide some feedback, I'd really appreciate it.