### PR TITLE
Mavrosflight rostime abstraction

### DIFF
--- a/rosflight/include/rosflight/mavrosflight/interface_adapter.h
+++ b/rosflight/include/rosflight/mavrosflight/interface_adapter.h
@@ -31,7 +31,7 @@
  */
 
 /**
- * @file logger_interface.h
+ * @file interface_adapter.h
  * @author Jacob Willis <jbwillis272@gmail.com>
  */
 

--- a/rosflight/include/rosflight/mavrosflight/mavrosflight.h
+++ b/rosflight/include/rosflight/mavrosflight/mavrosflight.h
@@ -64,7 +64,7 @@ public:
    */
   MavROSflight(MavlinkComm& mavlink_comm,
                LoggerInterface<DerivedLogger>& logger,
-               TimeInterface& time_interface,
+               const TimeInterface& time_interface,
                uint8_t sysid = 1,
                uint8_t compid = 50);
 

--- a/rosflight/include/rosflight/mavrosflight/mavrosflight.h
+++ b/rosflight/include/rosflight/mavrosflight/mavrosflight.h
@@ -64,6 +64,7 @@ public:
    */
   MavROSflight(MavlinkComm& mavlink_comm,
                LoggerInterface<DerivedLogger>& logger,
+               TimeInterface& time_intf,
                uint8_t sysid = 1,
                uint8_t compid = 50);
 

--- a/rosflight/include/rosflight/mavrosflight/mavrosflight.h
+++ b/rosflight/include/rosflight/mavrosflight/mavrosflight.h
@@ -64,7 +64,7 @@ public:
    */
   MavROSflight(MavlinkComm& mavlink_comm,
                LoggerInterface<DerivedLogger>& logger,
-               TimeInterface& time_intf,
+               TimeInterface& time_interface,
                uint8_t sysid = 1,
                uint8_t compid = 50);
 

--- a/rosflight/include/rosflight/mavrosflight/time_interface.h
+++ b/rosflight/include/rosflight/mavrosflight/time_interface.h
@@ -38,21 +38,18 @@
 #ifndef MAVROSFLIGHT_TIME_INTERFACE_H
 #define MAVROSFLIGHT_TIME_INTERFACE_H
 
-#include <cstdint>
+#include <chrono>
 
 namespace mavrosflight
 {
-typedef uint64_t time_ns_t;
 /**
  * \class TimeInterface
  * \brief Interface for acquiring system time
- *
- * For simplicity, times are int64_t, in nanoseconds.
  */
 class TimeInterface
 {
 public:
-  virtual time_ns_t now_ns() = 0;
+  virtual std::chrono::nanoseconds now_ns() = 0;
 };
 
 } // namespace mavrosflight

--- a/rosflight/include/rosflight/mavrosflight/time_interface.h
+++ b/rosflight/include/rosflight/mavrosflight/time_interface.h
@@ -1,0 +1,59 @@
+/*
+ * Software License Agreement (BSD-3 License)
+ *
+ * Copyright (c) 2020 Jacob Willis.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file time_interface.h
+ * @author Jacob Willis <jbwillis272@gmail.com>
+ */
+
+#ifndef MAVROSFLIGHT_TIME_INTERFACE_H
+#define MAVROSFLIGHT_TIME_INTERFACE_H
+
+#include <cstdint>
+
+namespace mavrosflight
+{
+typedef uint64_t time_ns_t;
+/**
+ * \class TimeInterface
+ * \brief Interface for acquiring system time
+ *
+ * For simplicity, times are int64_t, in nanoseconds.
+ */
+class TimeInterface
+{
+public:
+  virtual time_ns_t now_ns() = 0;
+};
+
+} // namespace mavrosflight
+#endif /* MAVROSFLIGHT_TIME_INTERFACE_H */

--- a/rosflight/include/rosflight/mavrosflight/time_interface.h
+++ b/rosflight/include/rosflight/mavrosflight/time_interface.h
@@ -49,7 +49,7 @@ namespace mavrosflight
 class TimeInterface
 {
 public:
-  virtual std::chrono::nanoseconds now_ns() const = 0;
+  virtual std::chrono::nanoseconds now() const = 0;
 };
 
 } // namespace mavrosflight

--- a/rosflight/include/rosflight/mavrosflight/time_interface.h
+++ b/rosflight/include/rosflight/mavrosflight/time_interface.h
@@ -49,7 +49,7 @@ namespace mavrosflight
 class TimeInterface
 {
 public:
-  virtual std::chrono::nanoseconds now_ns() = 0;
+  virtual std::chrono::nanoseconds now_ns() const = 0;
 };
 
 } // namespace mavrosflight

--- a/rosflight/include/rosflight/mavrosflight/time_manager.h
+++ b/rosflight/include/rosflight/mavrosflight/time_manager.h
@@ -45,8 +45,7 @@
 
 #include <ros/ros.h>
 
-#include <cstdint>
-#include <cstdlib>
+#include <chrono>
 
 namespace mavrosflight
 {
@@ -58,8 +57,7 @@ public:
 
   virtual void handle_mavlink_message(const mavlink_message_t &msg);
 
-  time_ns_t get_time_boot_ms(uint32_t boot_ms);
-  time_ns_t get_time_boot_us(uint64_t boot_us);
+  std::chrono::nanoseconds get_time_boot(std::chrono::nanoseconds boot_ns);
 
 private:
   MavlinkComm *comm_;
@@ -68,8 +66,7 @@ private:
   void timer_callback(const ros::TimerEvent &event);
 
   double offset_alpha_;
-  int64_t offset_ns_;
-  ros::Duration offset_;
+  std::chrono::nanoseconds offset_ns_;
 
   bool initialized_;
 

--- a/rosflight/include/rosflight/mavrosflight/time_manager.h
+++ b/rosflight/include/rosflight/mavrosflight/time_manager.h
@@ -74,7 +74,7 @@ private:
   bool initialized_;
 
   LoggerInterface<DerivedLogger> &logger_;
-  TimeInterface &time_intf_;
+  TimeInterface &time_interface_;
 };
 
 } // namespace mavrosflight

--- a/rosflight/include/rosflight/mavrosflight/time_manager.h
+++ b/rosflight/include/rosflight/mavrosflight/time_manager.h
@@ -53,7 +53,7 @@ template <typename DerivedLogger>
 class TimeManager : MavlinkListenerInterface
 {
 public:
-  TimeManager(MavlinkComm *comm, LoggerInterface<DerivedLogger> &logger, TimeInterface &time);
+  TimeManager(MavlinkComm *comm, LoggerInterface<DerivedLogger> &logger, const TimeInterface &time);
 
   virtual void handle_mavlink_message(const mavlink_message_t &msg);
 
@@ -71,7 +71,7 @@ private:
   bool initialized_;
 
   LoggerInterface<DerivedLogger> &logger_;
-  TimeInterface &time_interface_;
+  const TimeInterface &time_interface_;
 };
 
 } // namespace mavrosflight

--- a/rosflight/include/rosflight/mavrosflight/time_manager.h
+++ b/rosflight/include/rosflight/mavrosflight/time_manager.h
@@ -41,6 +41,7 @@
 #include <rosflight/mavrosflight/mavlink_bridge.h>
 #include <rosflight/mavrosflight/mavlink_comm.h>
 #include <rosflight/mavrosflight/mavlink_listener_interface.h>
+#include <rosflight/mavrosflight/time_interface.h>
 
 #include <ros/ros.h>
 
@@ -53,12 +54,12 @@ template <typename DerivedLogger>
 class TimeManager : MavlinkListenerInterface
 {
 public:
-  TimeManager(MavlinkComm *comm, LoggerInterface<DerivedLogger> &logger);
+  TimeManager(MavlinkComm *comm, LoggerInterface<DerivedLogger> &logger, TimeInterface &time);
 
   virtual void handle_mavlink_message(const mavlink_message_t &msg);
 
-  ros::Time get_ros_time_ms(uint32_t boot_ms);
-  ros::Time get_ros_time_us(uint64_t boot_us);
+  time_ns_t get_time_boot_ms(uint32_t boot_ms);
+  time_ns_t get_time_boot_us(uint64_t boot_us);
 
 private:
   MavlinkComm *comm_;
@@ -73,6 +74,7 @@ private:
   bool initialized_;
 
   LoggerInterface<DerivedLogger> &logger_;
+  TimeInterface &time_intf_;
 };
 
 } // namespace mavrosflight

--- a/rosflight/include/rosflight/mavrosflight/time_manager.h
+++ b/rosflight/include/rosflight/mavrosflight/time_manager.h
@@ -57,7 +57,7 @@ public:
 
   virtual void handle_mavlink_message(const mavlink_message_t &msg);
 
-  std::chrono::nanoseconds get_time_boot(std::chrono::nanoseconds boot_ns);
+  std::chrono::nanoseconds fcu_time_to_system_time(std::chrono::nanoseconds fcu_time);
 
 private:
   MavlinkComm *comm_;

--- a/rosflight/include/rosflight/ros_time.h
+++ b/rosflight/include/rosflight/ros_time.h
@@ -47,7 +47,7 @@ namespace rosflight
 class ROSTime : public mavrosflight::TimeInterface
 {
 public:
-  inline std::chrono::nanoseconds now_ns()
+  inline std::chrono::nanoseconds now_ns() const
   {
     std::chrono::nanoseconds now(ros::Time::now().toNSec());
     return now;

--- a/rosflight/include/rosflight/ros_time.h
+++ b/rosflight/include/rosflight/ros_time.h
@@ -47,7 +47,11 @@ namespace rosflight
 class ROSTime : public mavrosflight::TimeInterface
 {
 public:
-  inline mavrosflight::time_ns_t now_ns() { return ros::Time::now().toNSec(); }
+  inline std::chrono::nanoseconds now_ns()
+  {
+    std::chrono::nanoseconds now(ros::Time::now().toNSec());
+    return now;
+  }
 };
 
 } // namespace rosflight

--- a/rosflight/include/rosflight/ros_time.h
+++ b/rosflight/include/rosflight/ros_time.h
@@ -1,0 +1,55 @@
+/*
+ * Software License Agreement (BSD-3 License)
+ *
+ * Copyright (c) 2020 Jacob Willis.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file ros_time.h
+ * @author Jacob Willis <jbwillis272@gmail.com>
+ */
+
+#ifndef ROSFLIGHT_ROS_TIME_H
+#define ROSFLIGHT_ROS_TIME_H
+
+#include <rosflight/mavrosflight/time_interface.h>
+
+#include <ros/ros.h>
+
+namespace rosflight
+{
+class ROSTime : public mavrosflight::TimeInterface
+{
+public:
+  inline mavrosflight::time_ns_t now_ns() { return ros::Time::now().toNSec(); }
+};
+
+} // namespace rosflight
+
+#endif /* ROSFLIGHT_ROS_TIMER_H */

--- a/rosflight/include/rosflight/ros_time_interface.h
+++ b/rosflight/include/rosflight/ros_time_interface.h
@@ -47,10 +47,7 @@ namespace rosflight
 class ROSTimeInterface : public mavrosflight::TimeInterface
 {
 public:
-  inline std::chrono::nanoseconds now() const
-  {
-    return std::chrono::nanoseconds(ros::Time::now().toNSec());
-  }
+  inline std::chrono::nanoseconds now() const { return std::chrono::nanoseconds(ros::Time::now().toNSec()); }
 };
 
 } // namespace rosflight

--- a/rosflight/include/rosflight/ros_time_interface.h
+++ b/rosflight/include/rosflight/ros_time_interface.h
@@ -49,8 +49,7 @@ class ROSTimeInterface : public mavrosflight::TimeInterface
 public:
   inline std::chrono::nanoseconds now() const
   {
-    std::chrono::nanoseconds now(ros::Time::now().toNSec());
-    return now;
+    return std::chrono::nanoseconds(ros::Time::now().toNSec());
   }
 };
 

--- a/rosflight/include/rosflight/ros_time_interface.h
+++ b/rosflight/include/rosflight/ros_time_interface.h
@@ -47,7 +47,7 @@ namespace rosflight
 class ROSTimeInterface : public mavrosflight::TimeInterface
 {
 public:
-  inline std::chrono::nanoseconds now_ns() const
+  inline std::chrono::nanoseconds now() const
   {
     std::chrono::nanoseconds now(ros::Time::now().toNSec());
     return now;

--- a/rosflight/include/rosflight/ros_time_interface.h
+++ b/rosflight/include/rosflight/ros_time_interface.h
@@ -31,7 +31,7 @@
  */
 
 /**
- * @file ros_time.h
+ * @file ros_time_interface.h
  * @author Jacob Willis <jbwillis272@gmail.com>
  */
 
@@ -44,7 +44,7 @@
 
 namespace rosflight
 {
-class ROSTime : public mavrosflight::TimeInterface
+class ROSTimeInterface : public mavrosflight::TimeInterface
 {
 public:
   inline std::chrono::nanoseconds now_ns() const

--- a/rosflight/include/rosflight/rosflight_io.h
+++ b/rosflight/include/rosflight/rosflight_io.h
@@ -154,6 +154,7 @@ private:
   void request_version();
   void send_heartbeat();
   void check_error_code(uint8_t current, uint8_t previous, ROSFLIGHT_ERROR_CODE code, std::string name);
+  ros::Time fcu_time_to_ros_time(std::chrono::nanoseconds fcu_time);
 
   template <class T>
   inline T saturate(T value, T min, T max)

--- a/rosflight/include/rosflight/rosflight_io.h
+++ b/rosflight/include/rosflight/rosflight_io.h
@@ -81,6 +81,7 @@
 #include <rosflight/mavrosflight/mavrosflight.h>
 #include <rosflight/mavrosflight/param_listener_interface.h>
 #include <rosflight/ros_logger.h>
+#include <rosflight/ros_time.h>
 
 #include <geometry_msgs/Quaternion.h>
 
@@ -216,6 +217,9 @@ private:
 
   mavrosflight::MavlinkComm *mavlink_comm_;
   mavrosflight::MavROSflight<rosflight::ROSLogger> *mavrosflight_;
+
+  rosflight::ROSLogger logger_;
+  rosflight::ROSTime time_interface_;
 };
 
 } // namespace rosflight_io

--- a/rosflight/include/rosflight/rosflight_io.h
+++ b/rosflight/include/rosflight/rosflight_io.h
@@ -81,7 +81,7 @@
 #include <rosflight/mavrosflight/mavrosflight.h>
 #include <rosflight/mavrosflight/param_listener_interface.h>
 #include <rosflight/ros_logger.h>
-#include <rosflight/ros_time.h>
+#include <rosflight/ros_time_interface.h>
 
 #include <geometry_msgs/Quaternion.h>
 
@@ -219,7 +219,7 @@ private:
   mavrosflight::MavROSflight<rosflight::ROSLogger> *mavrosflight_;
 
   rosflight::ROSLogger logger_;
-  rosflight::ROSTime time_interface_;
+  rosflight::ROSTimeInterface time_interface_;
 };
 
 } // namespace rosflight_io

--- a/rosflight/src/mavrosflight/mavrosflight.cpp
+++ b/rosflight/src/mavrosflight/mavrosflight.cpp
@@ -45,7 +45,7 @@ using boost::asio::serial_port_base;
 template <typename DerivedLogger>
 MavROSflight<DerivedLogger>::MavROSflight(MavlinkComm &mavlink_comm,
                                           LoggerInterface<DerivedLogger> &logger,
-                                          TimeInterface &time_interface,
+                                          const TimeInterface &time_interface,
                                           uint8_t sysid /* = 1 */,
                                           uint8_t compid /* = 50 */) :
   comm(mavlink_comm),

--- a/rosflight/src/mavrosflight/mavrosflight.cpp
+++ b/rosflight/src/mavrosflight/mavrosflight.cpp
@@ -38,8 +38,6 @@
 #include <rosflight/mavrosflight/logger_interface.h>
 #include <rosflight/mavrosflight/mavrosflight.h>
 
-#include <ros/ros.h>
-
 namespace mavrosflight
 {
 using boost::asio::serial_port_base;
@@ -47,11 +45,12 @@ using boost::asio::serial_port_base;
 template <typename DerivedLogger>
 MavROSflight<DerivedLogger>::MavROSflight(MavlinkComm &mavlink_comm,
                                           LoggerInterface<DerivedLogger> &logger,
+                                          TimeInterface &time_intf,
                                           uint8_t sysid /* = 1 */,
                                           uint8_t compid /* = 50 */) :
   comm(mavlink_comm),
   param(&comm, logger),
-  time(&comm, logger),
+  time(&comm, logger, time_intf),
   sysid_(sysid),
   compid_(compid)
 {

--- a/rosflight/src/mavrosflight/mavrosflight.cpp
+++ b/rosflight/src/mavrosflight/mavrosflight.cpp
@@ -45,12 +45,12 @@ using boost::asio::serial_port_base;
 template <typename DerivedLogger>
 MavROSflight<DerivedLogger>::MavROSflight(MavlinkComm &mavlink_comm,
                                           LoggerInterface<DerivedLogger> &logger,
-                                          TimeInterface &time_intf,
+                                          TimeInterface &time_interface,
                                           uint8_t sysid /* = 1 */,
                                           uint8_t compid /* = 50 */) :
   comm(mavlink_comm),
   param(&comm, logger),
-  time(&comm, logger, time_intf),
+  time(&comm, logger, time_interface),
   sysid_(sysid),
   compid_(compid)
 {

--- a/rosflight/src/mavrosflight/mavrosflight.cpp
+++ b/rosflight/src/mavrosflight/mavrosflight.cpp
@@ -34,7 +34,7 @@
  * \author Daniel Koch <daniel.koch@byu.edu>
  */
 
-#include <rosflight/mavrosflight/logger_adapter.h>
+#include <rosflight/mavrosflight/interface_adapter.h>
 #include <rosflight/mavrosflight/logger_interface.h>
 #include <rosflight/mavrosflight/mavrosflight.h>
 

--- a/rosflight/src/mavrosflight/param_manager.cpp
+++ b/rosflight/src/mavrosflight/param_manager.cpp
@@ -35,7 +35,7 @@
  */
 
 #include <ros/ros.h>
-#include <rosflight/mavrosflight/logger_adapter.h>
+#include <rosflight/mavrosflight/interface_adapter.h>
 #include <rosflight/mavrosflight/logger_interface.h>
 #include <rosflight/mavrosflight/param_manager.h>
 #include <yaml-cpp/yaml.h>

--- a/rosflight/src/mavrosflight/time_manager.cpp
+++ b/rosflight/src/mavrosflight/time_manager.cpp
@@ -34,7 +34,7 @@
  * \author Daniel Koch <daniel.koch@byu.edu>
  */
 
-#include <rosflight/mavrosflight/logger_adapter.h>
+#include <rosflight/mavrosflight/interface_adapter.h>
 #include <rosflight/mavrosflight/logger_interface.h>
 #include <rosflight/mavrosflight/time_interface.h>
 #include <rosflight/mavrosflight/time_manager.h>

--- a/rosflight/src/mavrosflight/time_manager.cpp
+++ b/rosflight/src/mavrosflight/time_manager.cpp
@@ -71,7 +71,7 @@ void TimeManager<DerivedLogger>::handle_mavlink_message(const mavlink_message_t 
 
     std::chrono::nanoseconds tc1_chrono(tsync.tc1);
 
-    if (tc1_chrono > std::chrono::nanoseconds::zero()) // check that this is a response, not a request
+    if (tsync.tc1 > 0) // check that this is a response, not a request
     {
       std::chrono::nanoseconds ts1_chrono(tsync.ts1);
       std::chrono::nanoseconds offset_ns((ts1_chrono + now - 2 * tc1_chrono) / 2);

--- a/rosflight/src/mavrosflight/time_manager.cpp
+++ b/rosflight/src/mavrosflight/time_manager.cpp
@@ -44,14 +44,14 @@ namespace mavrosflight
 template <typename DerivedLogger>
 TimeManager<DerivedLogger>::TimeManager(MavlinkComm *comm,
                                         LoggerInterface<DerivedLogger> &logger,
-                                        TimeInterface &time_intf) :
+                                        TimeInterface &time_interface) :
   comm_(comm),
   offset_alpha_(0.95),
   offset_ns_(0),
   offset_(0.0),
   initialized_(false),
   logger_(logger),
-  time_intf_(time_intf)
+  time_interface_(time_interface)
 
 {
   comm_->register_mavlink_listener(this);
@@ -93,7 +93,7 @@ template <typename DerivedLogger>
 time_ns_t TimeManager<DerivedLogger>::get_time_boot_ms(uint32_t boot_ms)
 {
   if (!initialized_)
-    return time_intf_.now_ns();
+    return time_interface_.now_ns();
 
   int64_t boot_ns = (int64_t)boot_ms * 1000000;
 
@@ -102,7 +102,7 @@ time_ns_t TimeManager<DerivedLogger>::get_time_boot_ms(uint32_t boot_ms)
   {
     logger_.error_throttle(1, "negative time calculated from FCU: boot_ns=%ld, offset_ns=%ld.  Using system time",
                            boot_ns, offset_ns_);
-    return time_intf_.now_ns();
+    return time_interface_.now_ns();
   }
   return (time_ns_t)ns;
 }
@@ -111,7 +111,7 @@ template <typename DerivedLogger>
 time_ns_t TimeManager<DerivedLogger>::get_time_boot_us(uint64_t boot_us)
 {
   if (!initialized_)
-    return time_intf_.now_ns();
+    return time_interface_.now_ns();
 
   int64_t boot_ns = (int64_t)boot_us * 1000;
 
@@ -120,7 +120,7 @@ time_ns_t TimeManager<DerivedLogger>::get_time_boot_us(uint64_t boot_us)
   {
     logger_.error_throttle(1, "negative time calculated from FCU: boot_ns=%ld, offset_ns=%ld.  Using system time",
                            boot_ns, offset_ns_);
-    return time_intf_.now_ns();
+    return time_interface_.now_ns();
   }
   return (time_ns_t)ns;
 }

--- a/rosflight/src/mavrosflight/time_manager.cpp
+++ b/rosflight/src/mavrosflight/time_manager.cpp
@@ -44,7 +44,7 @@ namespace mavrosflight
 template <typename DerivedLogger>
 TimeManager<DerivedLogger>::TimeManager(MavlinkComm *comm,
                                         LoggerInterface<DerivedLogger> &logger,
-                                        TimeInterface &time_interface) :
+                                        const TimeInterface &time_interface) :
   comm_(comm),
   offset_alpha_(0.95),
   offset_ns_(0),

--- a/rosflight/src/mavrosflight/time_manager.cpp
+++ b/rosflight/src/mavrosflight/time_manager.cpp
@@ -95,16 +95,16 @@ void TimeManager<DerivedLogger>::handle_mavlink_message(const mavlink_message_t 
 }
 
 template <typename DerivedLogger>
-std::chrono::nanoseconds TimeManager<DerivedLogger>::get_time_boot(std::chrono::nanoseconds boot_ns)
+std::chrono::nanoseconds TimeManager<DerivedLogger>::fcu_time_to_system_time(std::chrono::nanoseconds fcu_time)
 {
   if (!initialized_)
     return time_interface_.now();
 
-  std::chrono::nanoseconds ns = boot_ns + offset_ns_;
+  std::chrono::nanoseconds ns = fcu_time + offset_ns_;
   if (ns < std::chrono::nanoseconds::zero())
   {
-    logger_.error_throttle(1, "negative time calculated from FCU: boot_ns=%ld, offset_ns=%ld.  Using system time",
-                           boot_ns, offset_ns_);
+    logger_.error_throttle(1, "negative time calculated from FCU: fcu_time=%ld, offset_ns=%ld.  Using system time",
+                           fcu_time, offset_ns_);
     return time_interface_.now();
   }
   return ns;

--- a/rosflight/src/rosflight_io.cpp
+++ b/rosflight/src/rosflight_io.cpp
@@ -43,7 +43,7 @@
 #include <rosflight/mavrosflight/mavlink_udp.h>
 #include <rosflight/mavrosflight/serial_exception.h>
 #include <rosflight/ros_logger.h>
-#include <rosflight/ros_time.h>
+#include <rosflight/ros_time_interface.h>
 #include <tf/tf.h>
 #include <cstdint>
 #include <eigen3/Eigen/Core>
@@ -104,7 +104,7 @@ rosflightIO::rosflightIO()
   {
     mavlink_comm_->open(); //! \todo move this into the MavROSflight constructor
     logger_ = rosflight::ROSLogger();
-    time_interface_ = rosflight::ROSTime();
+    time_interface_ = rosflight::ROSTimeInterface();
     mavrosflight_ = new mavrosflight::MavROSflight<rosflight::ROSLogger>(*mavlink_comm_, logger_, time_interface_);
   }
   catch (mavrosflight::SerialException e)

--- a/rosflight/src/rosflight_io.cpp
+++ b/rosflight/src/rosflight_io.cpp
@@ -104,8 +104,8 @@ rosflightIO::rosflightIO()
   {
     mavlink_comm_->open(); //! \todo move this into the MavROSflight constructor
     rosflight::ROSLogger logger;
-    rosflight::ROSTime time_intf;
-    mavrosflight_ = new mavrosflight::MavROSflight<rosflight::ROSLogger>(*mavlink_comm_, logger, time_intf);
+    rosflight::ROSTime time_interface;
+    mavrosflight_ = new mavrosflight::MavROSflight<rosflight::ROSLogger>(*mavlink_comm_, logger, time_interface);
   }
   catch (mavrosflight::SerialException e)
   {

--- a/rosflight/src/rosflight_io.cpp
+++ b/rosflight/src/rosflight_io.cpp
@@ -407,7 +407,8 @@ void rosflightIO::handle_attitude_quaternion_msg(const mavlink_message_t &msg)
 
   rosflight_msgs::Attitude attitude_msg;
   ros::Time now;
-  now.fromNSec(mavrosflight_->time.get_time_boot_ms(attitude.time_boot_ms));
+  std::chrono::milliseconds time_boot(attitude.time_boot_ms);
+  now.fromNSec(mavrosflight_->time.get_time_boot(std::chrono::nanoseconds(time_boot)).count());
   attitude_msg.header.stamp = now;
   attitude_msg.attitude.w = attitude.q1;
   attitude_msg.attitude.x = attitude.q2;
@@ -445,7 +446,8 @@ void rosflightIO::handle_small_imu_msg(const mavlink_message_t &msg)
 
   sensor_msgs::Imu imu_msg;
   ros::Time now;
-  now.fromNSec(mavrosflight_->time.get_time_boot_us(imu.time_boot_us));
+  std::chrono::microseconds time_boot(imu.time_boot_us);
+  now.fromNSec(mavrosflight_->time.get_time_boot(std::chrono::nanoseconds(time_boot)).count());
   imu_msg.header.stamp = now;
   imu_msg.header.frame_id = frame_id_;
   imu_msg.linear_acceleration.x = imu.xacc;
@@ -481,7 +483,8 @@ void rosflightIO::handle_rosflight_output_raw_msg(const mavlink_message_t &msg)
 
   rosflight_msgs::OutputRaw out_msg;
   ros::Time now;
-  now.fromNSec(mavrosflight_->time.get_time_boot_us(servo.stamp));
+  std::chrono::microseconds stamp(servo.stamp);
+  now.fromNSec(mavrosflight_->time.get_time_boot(std::chrono::nanoseconds(stamp)).count());
   out_msg.header.stamp = now;
   for (int i = 0; i < 14; i++)
   {
@@ -502,7 +505,8 @@ void rosflightIO::handle_rc_channels_raw_msg(const mavlink_message_t &msg)
 
   rosflight_msgs::RCRaw out_msg;
   ros::Time now;
-  now.fromNSec(mavrosflight_->time.get_time_boot_ms(rc.time_boot_ms));
+  std::chrono::milliseconds time_boot(rc.time_boot_ms);
+  now.fromNSec(mavrosflight_->time.get_time_boot(std::chrono::nanoseconds(time_boot)).count());
   out_msg.header.stamp = now;
 
   out_msg.values[0] = rc.chan1_raw;
@@ -796,7 +800,8 @@ void rosflightIO::handle_rosflight_gnss_msg(const mavlink_message_t &msg)
   mavlink_msg_rosflight_gnss_decode(&msg, &gnss);
 
   ros::Time stamp;
-  stamp.fromNSec(mavrosflight_->time.get_time_boot_us(gnss.rosflight_timestamp));
+  std::chrono::microseconds timestamp(gnss.rosflight_timestamp);
+  stamp.fromNSec(mavrosflight_->time.get_time_boot(std::chrono::nanoseconds(timestamp)).count());
 
   rosflight_msgs::GNSS gnss_msg;
   gnss_msg.header.stamp = stamp;

--- a/rosflight/src/rosflight_io.cpp
+++ b/rosflight/src/rosflight_io.cpp
@@ -103,9 +103,9 @@ rosflightIO::rosflightIO()
   try
   {
     mavlink_comm_->open(); //! \todo move this into the MavROSflight constructor
-    rosflight::ROSLogger logger;
-    rosflight::ROSTime time_interface;
-    mavrosflight_ = new mavrosflight::MavROSflight<rosflight::ROSLogger>(*mavlink_comm_, logger, time_interface);
+    logger_ = rosflight::ROSLogger();
+    time_interface_ = rosflight::ROSTime();
+    mavrosflight_ = new mavrosflight::MavROSflight<rosflight::ROSLogger>(*mavlink_comm_, logger_, time_interface_);
   }
   catch (mavrosflight::SerialException e)
   {


### PR DESCRIPTION
Abstract the use of `rostime` from `mavrosflight` and change all time types to `std::chrono` types.