### PR TITLE
fix: fixed convenience launch script path to multirotor firmware file

### DIFF
--- a/rosflight_sim/launch/multirotor_init_firmware.launch.py
+++ b/rosflight_sim/launch/multirotor_init_firmware.launch.py
@@ -25,7 +25,7 @@ def generate_launch_description():
             '/param_load_from_file ',
             'rosflight_msgs/srv/ParamFile ',
             '"{filename: "' + os.path.join(
-                get_package_share_directory('rosflight_sim'), 'params/multirotor_firmware.yaml"}'
+                get_package_share_directory('rosflight_sim'), 'params/multirotor_firmware/multirotor_combined.yaml"}'
             ) + '"'
         ]],
         shell=True


### PR DESCRIPTION
The previous PR failed to change the path to the firmware file for the convenience script, meaning this would launch file would fail if used.

This PR fixes that path.