### PR TITLE
feat: updated remaining bias walks to gauss-markov processes

### DIFF
--- a/rosflight_sim/simulators/standalone_sim/include/standalone_sensors.hpp
+++ b/rosflight_sim/simulators/standalone_sim/include/standalone_sensors.hpp
@@ -76,9 +76,12 @@ private:
   // TODO: Should we initialize this as non zero?
   Eigen::Vector3d gnss_gauss_markov_eta_ = Eigen::Vector3d::Zero();
   Eigen::Vector3d gyro_bias_gauss_markov_eta_ = Eigen::Vector3d::Zero();
+  Eigen::Vector3d acc_bias_gauss_markov_eta_ = Eigen::Vector3d::Zero();
   Eigen::Vector3d mag_gauss_markov_eta_ = Eigen::Vector3d::Zero();
   Eigen::Vector3d inertial_magnetic_field_ = Eigen::Vector3d::Zero();
   Eigen::Vector3d gyro_bias_instability_ = Eigen::Vector3d::Zero();
+  double baro_gauss_markov_eta_ = 0.0;
+  double airspeed_gauss_markov_eta_ = 0.0;
 
   double rho_ = 1.225;
 
@@ -86,6 +89,7 @@ private:
   Eigen::Vector3d gyro_bias_ = Eigen::Vector3d::Zero();
   Eigen::Vector3d acc_bias_ = Eigen::Vector3d::Zero();
   Eigen::Vector3d gyro_constant_bias_ = Eigen::Vector3d::Zero();
+  Eigen::Vector3d acc_constant_bias_ = Eigen::Vector3d::Zero();
   Eigen::Vector3d mag_bias_ = Eigen::Vector3d::Zero();
   double baro_bias_ = 0;
   double airspeed_bias_ = 0;

--- a/rosflight_sim/simulators/standalone_sim/include/standalone_sensors.hpp
+++ b/rosflight_sim/simulators/standalone_sim/include/standalone_sensors.hpp
@@ -80,9 +80,12 @@ private:
   // TODO: Should we initialize this as non zero?
   Eigen::Vector3d gnss_gauss_markov_eta_ = Eigen::Vector3d::Zero();
   Eigen::Vector3d gyro_bias_gauss_markov_eta_ = Eigen::Vector3d::Zero();
+  Eigen::Vector3d acc_bias_gauss_markov_eta_ = Eigen::Vector3d::Zero();
   Eigen::Vector3d mag_gauss_markov_eta_ = Eigen::Vector3d::Zero();
   Eigen::Vector3d inertial_magnetic_field_ = Eigen::Vector3d::Zero();
   Eigen::Vector3d gyro_bias_instability_ = Eigen::Vector3d::Zero();
+  double baro_gauss_markov_eta_ = 0.0;
+  double airspeed_gauss_markov_eta_ = 0.0;
 
   double rho_ = 1.225;
 
@@ -90,6 +93,7 @@ private:
   Eigen::Vector3d gyro_bias_ = Eigen::Vector3d::Zero();
   Eigen::Vector3d acc_bias_ = Eigen::Vector3d::Zero();
   Eigen::Vector3d gyro_constant_bias_ = Eigen::Vector3d::Zero();
+  Eigen::Vector3d acc_constant_bias_ = Eigen::Vector3d::Zero();
   Eigen::Vector3d mag_bias_ = Eigen::Vector3d::Zero();
   double baro_bias_ = 0;
   double airspeed_bias_ = 0;

--- a/rosflight_sim/simulators/standalone_sim/params/standalone_sim_params.yaml
+++ b/rosflight_sim/simulators/standalone_sim/params/standalone_sim_params.yaml
@@ -7,9 +7,11 @@
     gyro_stdev: 0.0226
     gyro_bias_range: 0.25
     gyro_bias_walk_stdev: 0.00001
+    k_gyro: 20.0
     acc_stdev: 0.2
     acc_bias_range: 0.6
     acc_bias_walk_stdev: 0.00001
+    k_acc: 20.0
     mag_stdev: 0.000003 # from nano tesla to tesla
     k_mag: 7.0
     inclination: 1.139436457
@@ -18,9 +20,11 @@
     baro_stdev: 4.0
     baro_bias_range: 500.0
     baro_bias_walk_stdev: 0.1
+    k_baro: 0.01
     airspeed_stdev: 1.15
     airspeed_bias_range: 0.15
     airspeed_bias_walk_stdev: 0.001
+    k_airspeed: 0.01
     range_stdev: 0.03
     range_min_range: 0.25
     range_max_range: 8.0

--- a/rosflight_sim/simulators/standalone_sim/src/standalone_sensors.cpp
+++ b/rosflight_sim/simulators/standalone_sim/src/standalone_sensors.cpp
@@ -69,20 +69,23 @@ void StandaloneSensors::declare_parameters()
   this->declare_parameter("acc_stdev", 0.2);
   this->declare_parameter("acc_bias_range", 0.6);
   this->declare_parameter("acc_bias_walk_stdev", 0.00001);
+  this->declare_parameter("k_acc", 20.0);
 
   this->declare_parameter("mag_stdev", 3000.0/1e9); // from nano tesla to tesla
   this->declare_parameter("k_mag", 7.0);
   this->declare_parameter("inclination", 1.139436457);
-  this->declare_parameter("declination", 0.1857972802);
+  this->declare_parameter("declination", 0.185004901);
   this->declare_parameter("total_intensity", 50716.3 / 1e9);  // nanoTesla converted to tesla.
 
   this->declare_parameter("baro_stdev", 4.0);
   this->declare_parameter("baro_bias_range", 500.0);
   this->declare_parameter("baro_bias_walk_stdev", 0.1);
+  this->declare_parameter("k_baro", 0.01);
 
   this->declare_parameter("airspeed_stdev", 1.15);
   this->declare_parameter("airspeed_bias_range", 0.15);
   this->declare_parameter("airspeed_bias_walk_stdev", 0.001);
+  this->declare_parameter("k_airspeed", 0.01);
 
   this->declare_parameter("range_stdev", 0.03);
   this->declare_parameter("range_min_range", 0.25);
@@ -117,7 +120,7 @@ void StandaloneSensors::initialize_sensors()
   double acc_bias_range = this->get_parameter("acc_bias_range").as_double();
   for (int i=0; i<3; ++i) {
     gyro_constant_bias_[i] = gyro_bias_range * uniform_distribution_(bias_generator_);
-    acc_bias_[i] = acc_bias_range * uniform_distribution_(bias_generator_);
+    acc_constant_bias_[i] = acc_bias_range * uniform_distribution_(bias_generator_);
   }
 
   gyro_bias_instability_ << this->get_parameter("gyro_bias_model_x0").as_double()
@@ -177,10 +180,9 @@ sensor_msgs::msg::Imu StandaloneSensors::imu_update(const rosflight_msgs::msg::S
     if (motors_spinning) {
       y_acc[i] += acc_stdev * normal_distribution_(noise_generator_);
     }
-
-    // Perform bias Walk for biases
-    y_acc[i] += acc_bias_[i];
   }
+
+  y_acc += acc_bias_;
 
   // Package acceleration into the output message
   out_msg.linear_acceleration.x = y_acc[0];
@@ -223,16 +225,19 @@ void StandaloneSensors::update_imu_biases()
   double gyro_bias_walk_stdev = this->get_parameter("gyro_bias_walk_stdev").as_double(); 
   double acc_bias_walk_stdev = this->get_parameter("acc_bias_walk_stdev").as_double(); 
 
-  // TODO: Do we need to scale this by dt? Look at what people do. The faster you run the imu, the faster the bias will change.
-  acc_bias_[0] += acc_bias_walk_stdev * normal_distribution_(noise_generator_);
-  acc_bias_[1] += acc_bias_walk_stdev * normal_distribution_(noise_generator_);
-  acc_bias_[2] += acc_bias_walk_stdev * normal_distribution_(noise_generator_);
+  double T_s = 1.0 / get_imu_update_frequency();
+  double k_acc = this->get_parameter("k_acc").as_double();
+  Eigen::Vector3d acc_noise;
+  acc_noise << acc_bias_walk_stdev * normal_distribution_(noise_generator_)
+            , acc_bias_walk_stdev * normal_distribution_(noise_generator_)
+            , acc_bias_walk_stdev * normal_distribution_(noise_generator_);
+  acc_bias_gauss_markov_eta_ = std::exp(-k_acc*T_s) * acc_bias_gauss_markov_eta_ + T_s*acc_noise;
+  acc_bias_ = acc_constant_bias_ + acc_bias_gauss_markov_eta_;
 
   Eigen::Vector3d noise;
   noise << gyro_bias_walk_stdev * normal_distribution_(noise_generator_)
         , gyro_bias_walk_stdev * normal_distribution_(noise_generator_)
         , gyro_bias_walk_stdev * normal_distribution_(noise_generator_);
-  double T_s = 1.0 / get_imu_update_frequency();
   double k_gyro = this->get_parameter("k_gyro").as_double();
   gyro_bias_gauss_markov_eta_ = std::exp(-k_gyro*T_s) * gyro_bias_gauss_markov_eta_ + T_s*noise;
 
@@ -311,13 +316,15 @@ rosflight_msgs::msg::Barometer StandaloneSensors::baro_update(const rosflight_ms
   double baro_stdev = this->get_parameter("baro_stdev").as_double(); 
   y_baro += baro_stdev * normal_distribution_(noise_generator_);
 
-  // Perform bias walk
+  // Increment the Gauss-Markov bias
   double baro_bias_walk_stdev = this->get_parameter("baro_bias_walk_stdev").as_double(); 
-  // TODO: Scale this by dt -- otherwise bias will change faster with a faster baro rate
-  baro_bias_ += baro_bias_walk_stdev * normal_distribution_(noise_generator_);
+  double noise = baro_bias_walk_stdev * normal_distribution_(noise_generator_);
+  double T_s = 1.0/get_baro_update_frequency();
+  double k_baro = this->get_parameter("k_baro").as_double();
+  baro_gauss_markov_eta_ = std::exp(-k_baro*T_s) * baro_gauss_markov_eta_ + T_s*noise;
 
-  // Add bias walk
-  y_baro += baro_bias_;
+  // Add bias
+  y_baro += baro_bias_ + baro_gauss_markov_eta_;
 
   // Package the return message
   rosflight_msgs::msg::Barometer out_msg;
@@ -445,10 +452,12 @@ rosflight_msgs::msg::Airspeed StandaloneSensors::diff_pressure_update(const rosf
 
   y_as += airspeed_stdev * normal_distribution_(noise_generator_);
 
-  // Perform bias walk
-  // TODO: Scale this by dt
-  airspeed_bias_ += airspeed_bias_walk_stdev * normal_distribution_(noise_generator_);
-  y_as += airspeed_bias_;
+  // Increment the Gauss-Markov bias
+  double noise = airspeed_bias_walk_stdev * normal_distribution_(noise_generator_);
+  double T_s = 1.0/get_diff_pressure_update_frequency();
+  double k_airspeed = this->get_parameter("k_airspeed").as_double();
+  airspeed_gauss_markov_eta_ = std::exp(-k_airspeed*T_s) * airspeed_gauss_markov_eta_ + T_s*noise;
+  y_as += airspeed_bias_ + airspeed_gauss_markov_eta_;
 
   // Package the return message 
   rosflight_msgs::msg::Airspeed out_msg;

--- a/rosflight_sim/simulators/standalone_sim/src/standalone_sensors.cpp
+++ b/rosflight_sim/simulators/standalone_sim/src/standalone_sensors.cpp
@@ -69,20 +69,23 @@ void StandaloneSensors::declare_parameters()
   this->declare_parameter("acc_stdev", 0.2);
   this->declare_parameter("acc_bias_range", 0.6);
   this->declare_parameter("acc_bias_walk_stdev", 0.00001);
+  this->declare_parameter("k_acc", 20.0);
 
   this->declare_parameter("mag_stdev", 3000.0 / 1e9); // from nano tesla to tesla
   this->declare_parameter("k_mag", 7.0);
   this->declare_parameter("inclination", 1.139436457);
-  this->declare_parameter("declination", 0.1857972802);
-  this->declare_parameter("total_intensity", 50716.3 / 1e9); // nanoTesla converted to tesla.
+  this->declare_parameter("declination", 0.185004901);
+  this->declare_parameter("total_intensity", 50716.3 / 1e9);  // nanoTesla converted to tesla.
 
   this->declare_parameter("baro_stdev", 4.0);
   this->declare_parameter("baro_bias_range", 500.0);
   this->declare_parameter("baro_bias_walk_stdev", 0.1);
+  this->declare_parameter("k_baro", 0.01);
 
   this->declare_parameter("airspeed_stdev", 1.15);
   this->declare_parameter("airspeed_bias_range", 0.15);
   this->declare_parameter("airspeed_bias_walk_stdev", 0.001);
+  this->declare_parameter("k_airspeed", 0.01);
 
   this->declare_parameter("range_stdev", 0.03);
   this->declare_parameter("range_min_range", 0.25);
@@ -117,7 +120,7 @@ void StandaloneSensors::initialize_sensors()
   double acc_bias_range = this->get_parameter("acc_bias_range").as_double();
   for (int i = 0; i < 3; ++i) {
     gyro_constant_bias_[i] = gyro_bias_range * uniform_distribution_(bias_generator_);
-    acc_bias_[i] = acc_bias_range * uniform_distribution_(bias_generator_);
+    acc_constant_bias_[i] = acc_bias_range * uniform_distribution_(bias_generator_);
   }
 
   gyro_bias_instability_ << this->get_parameter("gyro_bias_model_x0").as_double(),
@@ -177,10 +180,9 @@ StandaloneSensors::imu_update(const rosflight_msgs::msg::SimState & state,
     if (motors_spinning) {
       y_acc[i] += acc_stdev * normal_distribution_(noise_generator_);
     }
-
-    // Perform bias Walk for biases
-    y_acc[i] += acc_bias_[i];
   }
+
+  y_acc += acc_bias_;
 
   // Package acceleration into the output message
   out_msg.linear_acceleration.x = y_acc[0];
@@ -223,16 +225,19 @@ void StandaloneSensors::update_imu_biases()
   double gyro_bias_walk_stdev = this->get_parameter("gyro_bias_walk_stdev").as_double();
   double acc_bias_walk_stdev = this->get_parameter("acc_bias_walk_stdev").as_double();
 
-  // TODO: Do we need to scale this by dt? Look at what people do. The faster you run the imu, the faster the bias will change.
-  acc_bias_[0] += acc_bias_walk_stdev * normal_distribution_(noise_generator_);
-  acc_bias_[1] += acc_bias_walk_stdev * normal_distribution_(noise_generator_);
-  acc_bias_[2] += acc_bias_walk_stdev * normal_distribution_(noise_generator_);
+  double T_s = 1.0 / get_imu_update_frequency();
+  double k_acc = this->get_parameter("k_acc").as_double();
+  Eigen::Vector3d acc_noise;
+  acc_noise << acc_bias_walk_stdev * normal_distribution_(noise_generator_)
+            , acc_bias_walk_stdev * normal_distribution_(noise_generator_)
+            , acc_bias_walk_stdev * normal_distribution_(noise_generator_);
+  acc_bias_gauss_markov_eta_ = std::exp(-k_acc*T_s) * acc_bias_gauss_markov_eta_ + T_s*acc_noise;
+  acc_bias_ = acc_constant_bias_ + acc_bias_gauss_markov_eta_;
 
   Eigen::Vector3d noise;
-  noise << gyro_bias_walk_stdev * normal_distribution_(noise_generator_),
-    gyro_bias_walk_stdev * normal_distribution_(noise_generator_),
-    gyro_bias_walk_stdev * normal_distribution_(noise_generator_);
-  double T_s = 1.0 / get_imu_update_frequency();
+  noise << gyro_bias_walk_stdev * normal_distribution_(noise_generator_)
+        , gyro_bias_walk_stdev * normal_distribution_(noise_generator_)
+        , gyro_bias_walk_stdev * normal_distribution_(noise_generator_);
   double k_gyro = this->get_parameter("k_gyro").as_double();
   gyro_bias_gauss_markov_eta_ = std::exp(-k_gyro * T_s) * gyro_bias_gauss_markov_eta_ + T_s * noise;
 
@@ -311,13 +316,15 @@ StandaloneSensors::baro_update(const rosflight_msgs::msg::SimState & state)
   double baro_stdev = this->get_parameter("baro_stdev").as_double();
   y_baro += baro_stdev * normal_distribution_(noise_generator_);
 
-  // Perform bias walk
-  double baro_bias_walk_stdev = this->get_parameter("baro_bias_walk_stdev").as_double();
-  // TODO: Scale this by dt -- otherwise bias will change faster with a faster baro rate
-  baro_bias_ += baro_bias_walk_stdev * normal_distribution_(noise_generator_);
+  // Increment the Gauss-Markov bias
+  double baro_bias_walk_stdev = this->get_parameter("baro_bias_walk_stdev").as_double(); 
+  double noise = baro_bias_walk_stdev * normal_distribution_(noise_generator_);
+  double T_s = 1.0/get_baro_update_frequency();
+  double k_baro = this->get_parameter("k_baro").as_double();
+  baro_gauss_markov_eta_ = std::exp(-k_baro*T_s) * baro_gauss_markov_eta_ + T_s*noise;
 
-  // Add bias walk
-  y_baro += baro_bias_;
+  // Add bias
+  y_baro += baro_bias_ + baro_gauss_markov_eta_;
 
   // Package the return message
   rosflight_msgs::msg::Barometer out_msg;
@@ -449,10 +456,12 @@ StandaloneSensors::diff_pressure_update(const rosflight_msgs::msg::SimState & st
 
   y_as += airspeed_stdev * normal_distribution_(noise_generator_);
 
-  // Perform bias walk
-  // TODO: Scale this by dt
-  airspeed_bias_ += airspeed_bias_walk_stdev * normal_distribution_(noise_generator_);
-  y_as += airspeed_bias_;
+  // Increment the Gauss-Markov bias
+  double noise = airspeed_bias_walk_stdev * normal_distribution_(noise_generator_);
+  double T_s = 1.0/get_diff_pressure_update_frequency();
+  double k_airspeed = this->get_parameter("k_airspeed").as_double();
+  airspeed_gauss_markov_eta_ = std::exp(-k_airspeed*T_s) * airspeed_gauss_markov_eta_ + T_s*noise;
+  y_as += airspeed_bias_ + airspeed_gauss_markov_eta_;
 
   // Package the return message
   rosflight_msgs::msg::Airspeed out_msg;

--- a/rosflight_sim/simulators/standalone_sim/src/standalone_sensors.cpp
+++ b/rosflight_sim/simulators/standalone_sim/src/standalone_sensors.cpp
@@ -75,7 +75,7 @@ void StandaloneSensors::declare_parameters()
   this->declare_parameter("k_mag", 7.0);
   this->declare_parameter("inclination", 1.139436457);
   this->declare_parameter("declination", 0.185004901);
-  this->declare_parameter("total_intensity", 50716.3 / 1e9);  // nanoTesla converted to tesla.
+  this->declare_parameter("total_intensity", 50716.3 / 1e9); // nanoTesla converted to tesla.
 
   this->declare_parameter("baro_stdev", 4.0);
   this->declare_parameter("baro_bias_range", 500.0);
@@ -228,16 +228,17 @@ void StandaloneSensors::update_imu_biases()
   double T_s = 1.0 / get_imu_update_frequency();
   double k_acc = this->get_parameter("k_acc").as_double();
   Eigen::Vector3d acc_noise;
-  acc_noise << acc_bias_walk_stdev * normal_distribution_(noise_generator_)
-            , acc_bias_walk_stdev * normal_distribution_(noise_generator_)
-            , acc_bias_walk_stdev * normal_distribution_(noise_generator_);
-  acc_bias_gauss_markov_eta_ = std::exp(-k_acc*T_s) * acc_bias_gauss_markov_eta_ + T_s*acc_noise;
+  acc_noise << acc_bias_walk_stdev * normal_distribution_(noise_generator_),
+    acc_bias_walk_stdev * normal_distribution_(noise_generator_),
+    acc_bias_walk_stdev * normal_distribution_(noise_generator_);
+  acc_bias_gauss_markov_eta_ =
+    std::exp(-k_acc * T_s) * acc_bias_gauss_markov_eta_ + T_s * acc_noise;
   acc_bias_ = acc_constant_bias_ + acc_bias_gauss_markov_eta_;
 
   Eigen::Vector3d noise;
-  noise << gyro_bias_walk_stdev * normal_distribution_(noise_generator_)
-        , gyro_bias_walk_stdev * normal_distribution_(noise_generator_)
-        , gyro_bias_walk_stdev * normal_distribution_(noise_generator_);
+  noise << gyro_bias_walk_stdev * normal_distribution_(noise_generator_),
+    gyro_bias_walk_stdev * normal_distribution_(noise_generator_),
+    gyro_bias_walk_stdev * normal_distribution_(noise_generator_);
   double k_gyro = this->get_parameter("k_gyro").as_double();
   gyro_bias_gauss_markov_eta_ = std::exp(-k_gyro * T_s) * gyro_bias_gauss_markov_eta_ + T_s * noise;
 
@@ -317,11 +318,11 @@ StandaloneSensors::baro_update(const rosflight_msgs::msg::SimState & state)
   y_baro += baro_stdev * normal_distribution_(noise_generator_);
 
   // Increment the Gauss-Markov bias
-  double baro_bias_walk_stdev = this->get_parameter("baro_bias_walk_stdev").as_double(); 
+  double baro_bias_walk_stdev = this->get_parameter("baro_bias_walk_stdev").as_double();
   double noise = baro_bias_walk_stdev * normal_distribution_(noise_generator_);
-  double T_s = 1.0/get_baro_update_frequency();
+  double T_s = 1.0 / get_baro_update_frequency();
   double k_baro = this->get_parameter("k_baro").as_double();
-  baro_gauss_markov_eta_ = std::exp(-k_baro*T_s) * baro_gauss_markov_eta_ + T_s*noise;
+  baro_gauss_markov_eta_ = std::exp(-k_baro * T_s) * baro_gauss_markov_eta_ + T_s * noise;
 
   // Add bias
   y_baro += baro_bias_ + baro_gauss_markov_eta_;
@@ -458,9 +459,10 @@ StandaloneSensors::diff_pressure_update(const rosflight_msgs::msg::SimState & st
 
   // Increment the Gauss-Markov bias
   double noise = airspeed_bias_walk_stdev * normal_distribution_(noise_generator_);
-  double T_s = 1.0/get_diff_pressure_update_frequency();
+  double T_s = 1.0 / get_diff_pressure_update_frequency();
   double k_airspeed = this->get_parameter("k_airspeed").as_double();
-  airspeed_gauss_markov_eta_ = std::exp(-k_airspeed*T_s) * airspeed_gauss_markov_eta_ + T_s*noise;
+  airspeed_gauss_markov_eta_ =
+    std::exp(-k_airspeed * T_s) * airspeed_gauss_markov_eta_ + T_s * noise;
   y_as += airspeed_bias_ + airspeed_gauss_markov_eta_;
 
   // Package the return message


### PR DESCRIPTION
There were some Wiener process based bias walks left on the baro, airspeed and accel. I have changed these to be zero mean Gauss-Markov processes. This should more closely model the actual sensor bias behavior.

In the future, we could beef up the accel bias by adding an underlying model like we do for gyro. Similarly for the baro, we could add an underlying pressure model, resembling changing weather or whatever. 