### PR TITLE
Add HOST_UID build arg to Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,8 @@ ARG ROS_DISTRO=humble
 FROM osrf/ros:${ROS_DISTRO}-desktop
 ENV ROS_DISTRO=${ROS_DISTRO}
 SHELL [ "/bin/bash", "-c" ]
+# set default user ID
+ARG HOST_UID=1000
 
 # Update system
 RUN apt-get update \
@@ -24,7 +26,7 @@ RUN rosdep install --from-paths . --ignore-src -y \
     && rm -rf tmp
 
 # Create user
-RUN useradd -ms /usr/bin/zsh docker_user \
+RUN useradd -u ${HOST_UID} -ms /usr/bin/zsh docker_user \
     && usermod -aG sudo,dialout,plugdev docker_user \
     && echo "docker_user:pw" | chpasswd
 USER docker_user

--- a/docker/README.md
+++ b/docker/README.md
@@ -28,7 +28,8 @@ Make sure you have installed the Docker engine, as well as the Docker Compose ut
 1. Navigate to `/path/to/your/rosflight_ws` for the next commands. You could run these commands from the `src/rosflight_ros_pkgs/docker` directory if you want (changing the file paths as necessary).
 2. Build with:
     ```bash
-    docker compose -f src/rosflight_ros_pkgs/docker/compose.yaml build
+    # The HOST_UID=$(id -u) part sets the container's user to match your host user ID.
+    HOST_UID=$(id -u) docker compose -f src/rosflight_ros_pkgs/docker/compose.yaml build
     ```
 
 ## Running

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -6,6 +6,7 @@ services:
       dockerfile: src/rosflight_ros_pkgs/docker/Dockerfile
       args:
         - ROS_DISTRO=humble
+        - HOST_UID=${HOST_UID:-1000}
 
     # Enable interactive shell
     stdin_open: true


### PR DESCRIPTION
Problem
The Dockerfile hardcodes `docker_user` to UID 1000. Because the workspace is bind-mounted, host users whose UID isn't 1000 hit "Permission denied" when building in the mounted workspace (#252).

Fix
Added a `HOST_UID` build arg (default 1000) wired through compose into `useradd`, so the container user matches the host UID. Documented in the docker README.

Testing
- Default build → `uid=1000` (no regression)
- `HOST_UID=1234` build → `uid=1234`
- Non-1000 user could write to the workspace where it previously failed

Backwards compatible — omitting the arg behaves exactly as before.

Closes #252


