### PR TITLE
feat: add arg in compose file to select ros image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,8 @@
 ARG ROS_DISTRO=humble
+ARG ROS_IMAGE=osrf/ros:${ROS_DISTRO}-desktop
 
 # Base image
-FROM osrf/ros:${ROS_DISTRO}-desktop
+FROM ${ROS_IMAGE}
 ENV ROS_DISTRO=${ROS_DISTRO}
 SHELL [ "/bin/bash", "-c" ]
 # set default user ID

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,21 +3,19 @@ ARG ROS_IMAGE=osrf/ros:${ROS_DISTRO}-desktop
 
 # Base image
 FROM ${ROS_IMAGE}
-ENV ROS_DISTRO=${ROS_DISTRO}
 SHELL [ "/bin/bash", "-c" ]
 # set default user ID
 ARG HOST_UID=1000
 
-# Update system
+# Update system and install utilities/packages
+# $ROS_DISTRO is inherited from the base ROS_IMAGE
 RUN apt-get update \
-    && apt-get upgrade -y
-
-# Install utilities/packages
-RUN apt-get install\
-    ros-dev-tools\
-    ros-${ROS_DISTRO}-plotjuggler-ros\
-    zsh\
-    vim\
+    && apt-get upgrade -y \
+    && apt-get install \
+    ros-dev-tools \
+    ros-${ROS_DISTRO}-plotjuggler-ros \
+    zsh \
+    vim \
     -y
 
 # Install dependencies and build

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -7,8 +7,8 @@ services:
       args:
         - ROS_DISTRO=humble
         - HOST_UID=${HOST_UID:-1000}
-        # Uncomment this line to flash to a RaspberryPi (or another ARM-based device)
-        # - ROS_IMAGE=arm64v8/ros:jazzy-ros-base
+        # Uncomment the next line when building on an ARM64 device (e.g., Raspberry Pi). Keep ROS_IMAGE's tag consistent with ROS_DISTRO above.
+        # - ROS_IMAGE=arm64v8/ros:humble-ros-base
 
     # Enable interactive shell
     stdin_open: true

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -7,6 +7,8 @@ services:
       args:
         - ROS_DISTRO=humble
         - HOST_UID=${HOST_UID:-1000}
+        # Uncomment this line to flash to a RaspberryPi (or another ARM-based device)
+        # - ROS_IMAGE=arm64v8/ros:jazzy-ros-base
 
     # Enable interactive shell
     stdin_open: true


### PR DESCRIPTION
To use this Dockerfile on arm-based machines (e.g. RPi or Jetson Orin), we need to use a different base image. This PR adds a Dockerfile arg to select the ROS base image, and adds a comment in the compose.yaml file that users can uncomment when running on arm device. 

By default, the Dockerfile will pull the amd64-based image.
