### PR TITLE
Update for Ubuntu 26.04 and ROS 2 Lyrical

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,18 +4,26 @@ ARG ROS_IMAGE=osrf/ros:${ROS_DISTRO}-desktop
 # Base image
 FROM ${ROS_IMAGE}
 SHELL [ "/bin/bash", "-c" ]
-ARG HOST_UID=1000 # set default user ID
+
+# Set default args
+# Use the host UID for the container user to avoid mounted file permission issues
+ARG HOST_UID=1000
+ARG USER_SHELL=/usr/bin/bash
+ENV SHELL=${USER_SHELL}
 
 # Update system and install utilities/packages
 # $ROS_DISTRO is inherited from the base ROS_IMAGE
 RUN apt-get update \
     && apt-get upgrade -y \
-    && apt-get install \
+    && apt-get install -y \
     ros-dev-tools \
-    ros-${ROS_DISTRO}-plotjuggler \
     zsh \
     vim \
-    -y
+    && if apt-cache show "ros-${ROS_DISTRO}-plotjuggler-ros" >/dev/null 2>&1; then \
+        apt-get install -y "ros-${ROS_DISTRO}-plotjuggler-ros"; \
+    else \
+        apt-get install -y "ros-${ROS_DISTRO}-plotjuggler"; \
+    fi
 
 # Install dependencies and build
 WORKDIR /rosflight_ws
@@ -23,23 +31,46 @@ COPY src tmp
 RUN rosdep install --from-paths . --ignore-src -y \
     && rm -rf tmp
 
-# Add default "ubuntu" user to needed groups
+# Add user to needed groups with password "pw"
 RUN if ! getent passwd ${HOST_UID}; then \
-        useradd -u ${HOST_UID} -ms /usr/bin/zsh ubuntu; \
+        useradd -u ${HOST_UID} -ms "${USER_SHELL}" ubuntu; \
     fi \
     && usermod -aG sudo,dialout,plugdev ubuntu \
     && echo "ubuntu:pw" | chpasswd
 USER ubuntu
 
-# Setup ROS environment variables
-RUN echo "source /rosflight_ws/install/setup.zsh" >> /home/ubuntu/.zshrc
+# Source ROS environment variables with autocompletion
+RUN echo 'source ~/.rosrc' >> /home/ubuntu/.bashrc \
+    && cp /etc/zsh/newuser.zshrc.recommended ~/.zshrc \
+    && if [[ "${ROS_DISTRO}" == "humble" ]]; then \
+         echo 'autoload -U +X bashcompinit && bashcompinit' >> /home/ubuntu/.zshrc; \
+       fi \
+    && echo 'source ~/.rosrc' >> /home/ubuntu/.zshrc \
+    && cat > /home/ubuntu/.rosrc <<EOF
+if [ -n "\$BASH" ]; then
+  source /opt/ros/${ROS_DISTRO}/setup.bash
+  if [ -f /rosflight_ws/install/local_setup.bash ]; then
+    source /rosflight_ws/install/local_setup.bash
+  fi
+elif [ -n "\$ZSH_NAME" ]; then
+  source /opt/ros/${ROS_DISTRO}/setup.zsh
+  if [ -f /rosflight_ws/install/local_setup.zsh ]; then
+    source /rosflight_ws/install/local_setup.zsh
+  fi
+  if command -v register-python-argcomplete >/dev/null 2>&1; then
+    eval "\$(register-python-argcomplete ros2)"
+    eval "\$(register-python-argcomplete colcon)"
+  elif command -v register-python-argcomplete3 >/dev/null 2>&1; then
+    eval "\$(register-python-argcomplete3 ros2)"
+    eval "\$(register-python-argcomplete3 colcon)"
+  fi
+else
+  source /opt/ros/${ROS_DISTRO}/setup.sh
+  if [ -f /rosflight_ws/install/local_setup.sh ]; then
+    source /rosflight_ws/install/local_setup.sh
+  fi
+fi
+EOF
 
-# Add autocompletion for ROS commands with zsh
-RUN echo 'eval "$(register-python-argcomplete ros2)"' >> /home/ubuntu/.zshrc \
-    && echo 'eval "$(register-python-argcomplete colcon)"' >> /home/ubuntu/.zshrc
-
-# Temporary fix for running ROS in Docker
-RUN echo "ulimit -n 1024" >> /home/ubuntu/.zshrc
-
-ENTRYPOINT [ "/usr/bin/zsh" ]
-
+# Create dynamic entry point (can set SHELL as an arg when entering container)
+ENTRYPOINT exec "$SHELL"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,10 @@
-ARG ROS_DISTRO=humble
+ARG ROS_DISTRO=lyrical
 ARG ROS_IMAGE=osrf/ros:${ROS_DISTRO}-desktop
 
 # Base image
 FROM ${ROS_IMAGE}
 SHELL [ "/bin/bash", "-c" ]
-# set default user ID
-ARG HOST_UID=1000
+ARG HOST_UID=1000 # set default user ID
 
 # Update system and install utilities/packages
 # $ROS_DISTRO is inherited from the base ROS_IMAGE
@@ -13,7 +12,7 @@ RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install \
     ros-dev-tools \
-    ros-${ROS_DISTRO}-plotjuggler-ros \
+    ros-${ROS_DISTRO}-plotjuggler \
     zsh \
     vim \
     -y
@@ -24,22 +23,23 @@ COPY src tmp
 RUN rosdep install --from-paths . --ignore-src -y \
     && rm -rf tmp
 
-# Create user
-RUN useradd -u ${HOST_UID} -ms /usr/bin/zsh docker_user \
-    && usermod -aG sudo,dialout,plugdev docker_user \
-    && echo "docker_user:pw" | chpasswd
-USER docker_user
+# Add default "ubuntu" user to needed groups
+RUN if ! getent passwd ${HOST_UID}; then \
+        useradd -u ${HOST_UID} -ms /usr/bin/zsh ubuntu; \
+    fi \
+    && usermod -aG sudo,dialout,plugdev ubuntu \
+    && echo "ubuntu:pw" | chpasswd
+USER ubuntu
 
 # Setup ROS environment variables
-RUN echo "source /opt/ros/${ROS_DISTRO}/setup.zsh" >> /home/docker_user/.zshrc \
-    && echo "source /rosflight_ws/install/setup.zsh" >> /home/docker_user/.zshrc
+RUN echo "source /rosflight_ws/install/setup.zsh" >> /home/ubuntu/.zshrc
 
 # Add autocompletion for ROS commands with zsh
-RUN echo "eval $(register-python-argcomplete3 ros2)" >> /home/docker_user/.zshrc \
-    && echo "eval $(register-python-argcomplete3 colcon)" >> /home/docker_user/.zshrc
+RUN echo 'eval "$(register-python-argcomplete ros2)"' >> /home/ubuntu/.zshrc \
+    && echo 'eval "$(register-python-argcomplete colcon)"' >> /home/ubuntu/.zshrc
 
 # Temporary fix for running ROS in Docker
-RUN echo "ulimit -n 1024" >> /home/docker_user/.zshrc
+RUN echo "ulimit -n 1024" >> /home/ubuntu/.zshrc
 
 ENTRYPOINT [ "/usr/bin/zsh" ]
 

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -5,8 +5,9 @@ services:
       context: ../../..
       dockerfile: src/rosflight_ros_pkgs/docker/Dockerfile
       args:
-        - ROS_DISTRO=lyrical
+        - ROS_DISTRO=${ROS_DISTRO:-lyrical}
         - HOST_UID=${HOST_UID:-1000}
+        - USER_SHELL=${USER_SHELL:-/usr/bin/bash}
         # Uncomment the next line when building on an ARM64 device (e.g., Raspberry Pi). Keep ROS_IMAGE's tag consistent with ROS_DISTRO above.
         # - ROS_IMAGE=arm64v8/ros:humble-ros-base
 

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -5,7 +5,7 @@ services:
       context: ../../..
       dockerfile: src/rosflight_ros_pkgs/docker/Dockerfile
       args:
-        - ROS_DISTRO=humble
+        - ROS_DISTRO=lyrical
         - HOST_UID=${HOST_UID:-1000}
         # Uncomment the next line when building on an ARM64 device (e.g., Raspberry Pi). Keep ROS_IMAGE's tag consistent with ROS_DISTRO above.
         # - ROS_IMAGE=arm64v8/ros:humble-ros-base

--- a/rosflight_compat/CMakeLists.txt
+++ b/rosflight_compat/CMakeLists.txt
@@ -1,0 +1,58 @@
+cmake_minimum_required(VERSION 3.20...3.28)
+project(rosflight_compat)
+
+# Acknowledge variable does not need to be used since this file only defines
+# a header-only library (suppresses cmake warning)
+if(DEFINED CMAKE_EXPORT_COMPILE_COMMANDS)
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ${CMAKE_EXPORT_COMPILE_COMMANDS})
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+
+###############
+## Libraries ##
+###############
+
+add_library(rosflight_compat_headers INTERFACE)
+add_library(rosflight_compat::compat_headers ALIAS rosflight_compat_headers)
+set_target_properties(rosflight_compat_headers PROPERTIES
+  EXPORT_NAME compat_headers
+)
+target_include_directories(rosflight_compat_headers INTERFACE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(rosflight_compat_headers INTERFACE rclcpp::rclcpp)
+
+#############
+## Install ##
+#############
+
+# Headers for exported/public libraries
+install(
+  DIRECTORY include/
+  DESTINATION "include/${PROJECT_NAME}"
+)
+
+# Exported/public libraries
+install(
+  TARGETS
+    rosflight_compat_headers
+  EXPORT "export_${PROJECT_NAME}"
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+########################
+### ROS Finalization ###
+########################
+
+# Export public libraries
+ament_export_targets("export_${PROJECT_NAME}" HAS_LIBRARY_TARGET)
+
+# Export public cmake package dependencies (not targets)
+ament_export_dependencies(rclcpp)
+
+ament_package()

--- a/rosflight_compat/include/rosflight_compat/service_client.hpp
+++ b/rosflight_compat/include/rosflight_compat/service_client.hpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 BYU MAGICC Lab.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * * Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * * Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * * Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+ * This file was created to provide backwards compatiblitiy for ROS 2 Humble.
+ * Humble uses deprecated C types (rmw_qos_profile_services_default) while
+ * later versions of ROS 2 migrated to C++ types: ServicesQoS().
+ *
+ * TODO: Once Humble is not longer supported, this compatiblitiy layer can be
+ * deleted and all files using it should change to create the clients directly
+ * using the modern ServicesQoS() type.
+ */
+
+#ifndef ROSFLIGHT_COMPAT_SERVICE_CLIENT_HPP
+#define ROSFLIGHT_COMPAT_SERVICE_CLIENT_HPP
+
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/version.h>
+#include <rmw/qos_profiles.h>
+
+namespace rosflight_compat
+{
+
+template<typename ServiceT>
+typename rclcpp::Client<ServiceT>::SharedPtr create_service_client(
+  rclcpp::Node & node,
+  const std::string & service_name,
+  rclcpp::CallbackGroup::SharedPtr callback_group)
+{
+#if RCLCPP_VERSION_MAJOR < 21
+  // legacy version for ROS 2 Humble on Ubuntu 22.04
+  return node.create_client<ServiceT>(
+    service_name,
+    rmw_qos_profile_services_default,
+    callback_group);
+#else
+  // modern version
+  return node.create_client<ServiceT>(
+    service_name,
+    rclcpp::ServicesQoS(),
+    callback_group);
+#endif
+}
+
+}  // namespace rosflight_compat
+
+#endif // ROSFLIGHT_COMPAT_SERVICE_CLIENT_HPP

--- a/rosflight_compat/package.xml
+++ b/rosflight_compat/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>rosflight_compat</name>
+  <version>2.0.0</version>
+  <description>ROSflight compatibility headers</description>
+
+  <maintainer email="brandonsutherland2@gmail.com">Brandon Sutherland</maintainer>
+
+  <author email="mhaskell9@gmail.com">Mathew Haskell</author>
+
+  <license>BSD</license>
+
+  <url type="website">https://rosflight.org</url>
+  <url type="repository">https://github.com/rosflight/rosflight_ros_pkgs</url>
+  <url type="bugtracker">https://github.com/rosflight/rosflight_ros_pkgs/issues</url>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rosflight_gcs/CMakeLists.txt
+++ b/rosflight_gcs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20...3.28)
 project(rosflight_gcs)
 
 if(NOT CMAKE_C_STANDARD)

--- a/rosflight_gcs/CMakeLists.txt
+++ b/rosflight_gcs/CMakeLists.txt
@@ -23,24 +23,18 @@ find_package(visualization_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 
-include_directories(include
-  ${ament_INCLUDE_DIRS}
-  ${rclcpp_INCLUDE_DIRS}
-)
+include_directories(include)
 
 # viz executable
 add_executable(viz src/viz.cpp)
-target_link_libraries(viz
-  ${rclcpp_LIBRARIES}
-  ${ament_LIBRARIES}
-)
-ament_target_dependencies(viz
-  geometry_msgs
-  rosflight_msgs
-  sensor_msgs
-  tf2
-  tf2_geometry_msgs
-  visualization_msgs
+target_link_libraries(viz PRIVATE
+  rclcpp::rclcpp
+  geometry_msgs::geometry_msgs
+  rosflight_msgs::rosflight_msgs
+  sensor_msgs::sensor_msgs
+  tf2::tf2
+  tf2_geometry_msgs::tf2_geometry_msgs
+  visualization_msgs::visualization_msgs
 )
 
 # Install header files

--- a/rosflight_gcs/CMakeLists.txt
+++ b/rosflight_gcs/CMakeLists.txt
@@ -12,7 +12,7 @@ add_compile_options(-Wall)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
-endif(NOT CMAKE_BUILD_TYPE)
+endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/rosflight_gcs/include/rosflight_gcs/viz.hpp
+++ b/rosflight_gcs/include/rosflight_gcs/viz.hpp
@@ -42,7 +42,6 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rosflight_msgs/msg/attitude.hpp>
 #include <sensor_msgs/msg/magnetic_field.hpp>
-#include <tf2/LinearMath/Quaternion.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <visualization_msgs/msg/marker.hpp>
 

--- a/rosflight_gcs/launch/viz_att.launch.py
+++ b/rosflight_gcs/launch/viz_att.launch.py
@@ -6,11 +6,10 @@ Last Modified: June 28, 2023
 Description: ROS2 launch file used to launch attitude Rviz visualization.
 """
 
-from ament_index_python import get_package_share_directory
-
 from launch import LaunchDescription
 from launch.actions import GroupAction
 from launch.substitutions import PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
 from launch_ros.actions import Node, PushRosNamespace
 
 
@@ -19,7 +18,7 @@ def generate_launch_description():
 
     # Get rviz config filepath
     rviz2_config_file = PathJoinSubstitution(
-        [get_package_share_directory('rosflight_gcs'), 'rviz', 'viz_att.rviz']
+        [FindPackageShare('rosflight_gcs'), 'rviz', 'viz_att.rviz']
     )
 
     # Launch rviz

--- a/rosflight_gcs/launch/viz_mag.launch.py
+++ b/rosflight_gcs/launch/viz_mag.launch.py
@@ -6,11 +6,11 @@ Last Modified: June 28, 2023
 Description: ROS2 launch file used to launch magnetometer Rviz visualization.
 """
 
-from ament_index_python import get_package_share_directory
 
 from launch import LaunchDescription
 from launch.actions import GroupAction
 from launch.substitutions import PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
 from launch_ros.actions import Node, PushRosNamespace
 
 
@@ -19,7 +19,7 @@ def generate_launch_description():
 
     # Get rviz config filepath
     rviz2_config_file = PathJoinSubstitution(
-        [get_package_share_directory('rosflight_gcs'), 'rviz', 'viz_mag.rviz']
+        [FindPackageShare('rosflight_gcs'), 'rviz', 'viz_mag.rviz']
     )
 
     # Launch rviz

--- a/rosflight_gcs/package.xml
+++ b/rosflight_gcs/package.xml
@@ -26,7 +26,6 @@
   <depend>tf2_geometry_msgs</depend>
 
   <depend>rosflight_msgs</depend>
-  <depend>rosflight_io</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rosflight_io/CMakeLists.txt
+++ b/rosflight_io/CMakeLists.txt
@@ -12,7 +12,7 @@ add_compile_options(-Wall)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
-endif(NOT CMAKE_BUILD_TYPE)
+endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -35,8 +35,8 @@ set(FIRMWARE_SUBMODULE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../rosflight_firmware")
 if(NOT EXISTS "${FIRMWARE_SUBMODULE_DIR}/.git")
   message(STATUS "Firmware submodule not found at ${FIRMWARE_SUBMODULE_DIR}")
   execute_process(
-          COMMAND git submodule update --init --recursive
-          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMAND git submodule update --init --recursive
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   )
 endif()
 
@@ -45,14 +45,14 @@ set(FIRMWARE_INCLUDE_DIRS
   ../rosflight_firmware/include/interface/
   ../rosflight_firmware/lib/
   ../rosflight_firmware/comms/
-  # ../rosflight_firmware/test/
 )
 
 # Determine ROSflight version
 execute_process(
   COMMAND git describe --tags --abbrev=8 --always --dirty --long
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  OUTPUT_VARIABLE GIT_VERSION_STRING RESULT_VARIABLE GIT_RESULT)
+  OUTPUT_VARIABLE GIT_VERSION_STRING RESULT_VARIABLE GIT_RESULT
+)
 if(GIT_RESULT EQUAL 0)
   string(REGEX REPLACE "\n$" "" GIT_VERSION_STRING "${GIT_VERSION_STRING}") # remove trailing newline
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DROSFLIGHT_VERSION=${GIT_VERSION_STRING}")
@@ -67,7 +67,7 @@ endif()
 
 include_directories(include
   ${FIRMWARE_INCLUDE_DIRS}
-  )
+)
 
 # mavrosflight library
 add_library(mavrosflight
@@ -78,23 +78,23 @@ add_library(mavrosflight
   src/mavrosflight/param_manager.cpp
   src/mavrosflight/param.cpp
   src/mavrosflight/time_manager.cpp
-  )
+)
 target_compile_options(mavrosflight PRIVATE -Wno-address-of-packed-member)
 target_link_libraries(mavrosflight PRIVATE
   rclcpp::rclcpp
   yaml-cpp::yaml-cpp
   Boost::headers
   Boost::thread
-  )
+)
 
 # realtime_configurator library
 add_library(realtime_configurator SHARED
   src/realtime_configurator.cpp
-  )
-target_include_directories(realtime_configurator
-  PUBLIC
-    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-    "$<INSTALL_INTERFACE:include>")
+)
+target_include_directories(realtime_configurator PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include>"
+)
 target_link_libraries(realtime_configurator PRIVATE
   rclcpp::rclcpp
   std_msgs::std_msgs
@@ -106,7 +106,7 @@ add_executable(rosflight_io
   src/rosflight_io_node.cpp
   src/rosflight_io.cpp
   src/magnetometer_calibration.cpp
-  )
+)
 target_compile_options(rosflight_io PRIVATE -Wno-address-of-packed-member)
 target_link_libraries(rosflight_io PRIVATE
   mavrosflight
@@ -132,14 +132,14 @@ install(TARGETS mavrosflight rosflight_io
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION lib/${PROJECT_NAME}
-  )
+)
 
 # Mark cpp header files for installation
 install(DIRECTORY include/rosflight_io/mavrosflight/
   DESTINATION include/${PROJECT_NAME}
   FILES_MATCHING PATTERN "*.h"
   PATTERN ".svn" EXCLUDE
-  )
+)
 
 install(TARGETS realtime_configurator
   EXPORT export_realtime_configurator
@@ -147,11 +147,10 @@ install(TARGETS realtime_configurator
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
   INCLUDES DESTINATION include
-  )
+)
 
 install(FILES include/rosflight_io/realtime_configurator.hpp
   DESTINATION include
-  )
-
+)
 
 ament_package()

--- a/rosflight_io/CMakeLists.txt
+++ b/rosflight_io/CMakeLists.txt
@@ -16,7 +16,6 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(eigen_stl_containers REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(rosflight_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)

--- a/rosflight_io/CMakeLists.txt
+++ b/rosflight_io/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20...3.28)
 project(rosflight_io)
 
 if(NOT CMAKE_C_STANDARD)

--- a/rosflight_io/CMakeLists.txt
+++ b/rosflight_io/CMakeLists.txt
@@ -28,9 +28,7 @@ find_package(message_filters REQUIRED)
 
 find_package(Boost CONFIG REQUIRED COMPONENTS thread)
 find_package(Eigen3 REQUIRED)
-
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(YAML_CPP REQUIRED yaml-cpp)
+find_package(yaml-cpp REQUIRED)
 
 # clone firmware submodule if it is missing
 set(FIRMWARE_SUBMODULE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../rosflight_firmware")
@@ -68,7 +66,6 @@ endif()
 ###########
 
 include_directories(include
-  ${YAML_CPP_INCLUDEDIR}
   ${FIRMWARE_INCLUDE_DIRS}
   )
 
@@ -85,7 +82,7 @@ add_library(mavrosflight
 target_compile_options(mavrosflight PRIVATE -Wno-address-of-packed-member)
 target_link_libraries(mavrosflight PRIVATE
   rclcpp::rclcpp
-  ${YAML_CPP_LIBRARIES}
+  yaml-cpp::yaml-cpp
   Boost::headers
   Boost::thread
   )

--- a/rosflight_io/CMakeLists.txt
+++ b/rosflight_io/CMakeLists.txt
@@ -29,6 +29,15 @@ find_package(Boost CONFIG REQUIRED COMPONENTS thread)
 find_package(Eigen3 REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
+# Legacy yaml-cpp support for Ubuntu 22.04
+if(NOT TARGET yaml-cpp::yaml-cpp)
+  add_library(yaml-cpp::yaml-cpp INTERFACE IMPORTED)
+  set_target_properties(yaml-cpp::yaml-cpp PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${YAML_CPP_INCLUDE_DIR}"
+    INTERFACE_LINK_LIBRARIES "${YAML_CPP_LIBRARIES}"
+  )
+endif()
+
 # clone firmware submodule if it is missing
 set(FIRMWARE_SUBMODULE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../rosflight_firmware")
 if(NOT EXISTS "${FIRMWARE_SUBMODULE_DIR}/.git")

--- a/rosflight_io/CMakeLists.txt
+++ b/rosflight_io/CMakeLists.txt
@@ -68,10 +68,7 @@ endif()
 ###########
 
 include_directories(include
-  ${ament_INCLUDE_DIRS}
-  ${rclcpp_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIRS}
-  ${EIGEN3_INCLUDE_DIRS}
   ${YAML_CPP_INCLUDEDIR}
   ${FIRMWARE_INCLUDE_DIRS}
   )
@@ -87,13 +84,12 @@ add_library(mavrosflight
   src/mavrosflight/time_manager.cpp
   )
 target_compile_options(mavrosflight PRIVATE -Wno-address-of-packed-member)
-target_link_libraries(mavrosflight
-  ${ament_LIBRARIES}
-  ${rclcpp_LIBRARIES}
-  ${Boost_LIBRARIES}
+target_link_libraries(mavrosflight PRIVATE
+  rclcpp::rclcpp
   ${YAML_CPP_LIBRARIES}
+  Boost::headers
+  Boost::thread
   )
-ament_target_dependencies(mavrosflight rclcpp)
 
 # realtime_configurator library
 add_library(realtime_configurator SHARED
@@ -103,10 +99,10 @@ target_include_directories(realtime_configurator
   PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
     "$<INSTALL_INTERFACE:include>")
-ament_target_dependencies(realtime_configurator
-  rclcpp
-  std_msgs
-  )
+target_link_libraries(realtime_configurator PRIVATE
+  rclcpp::rclcpp
+  std_msgs::std_msgs
+)
 ament_export_targets(export_realtime_configurator HAS_LIBRARY_TARGET)
 
 # rosflight_io_node
@@ -116,23 +112,20 @@ add_executable(rosflight_io
   src/magnetometer_calibration.cpp
   )
 target_compile_options(rosflight_io PRIVATE -Wno-address-of-packed-member)
-target_link_libraries(rosflight_io
+target_link_libraries(rosflight_io PRIVATE
   mavrosflight
   realtime_configurator
-  ${rclcpp_LIBRARIES}
-  ${ament_LIBRARIES}
-  ${Boost_LIBRARES}
-  )
-ament_target_dependencies(rosflight_io
-  geometry_msgs
-  rosflight_msgs
-  sensor_msgs
-  std_msgs
-  std_srvs
-  tf2
-  tf2_geometry_msgs
-  Eigen3
-  )
+  rclcpp::rclcpp
+  geometry_msgs::geometry_msgs
+  rosflight_msgs::rosflight_msgs
+  sensor_msgs::sensor_msgs
+  std_msgs::std_msgs
+  std_srvs::std_srvs
+  tf2::tf2
+  tf2_geometry_msgs::tf2_geometry_msgs
+  Boost::headers
+  Eigen3::Eigen
+)
 
 #############
 ## Install ##

--- a/rosflight_io/CMakeLists.txt
+++ b/rosflight_io/CMakeLists.txt
@@ -26,7 +26,7 @@ find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(message_filters REQUIRED)
 
-find_package(Boost REQUIRED COMPONENTS system thread)
+find_package(Boost CONFIG REQUIRED COMPONENTS thread)
 find_package(Eigen3 REQUIRED)
 
 find_package(PkgConfig REQUIRED)
@@ -68,7 +68,6 @@ endif()
 ###########
 
 include_directories(include
-  ${Boost_INCLUDE_DIRS}
   ${YAML_CPP_INCLUDEDIR}
   ${FIRMWARE_INCLUDE_DIRS}
   )

--- a/rosflight_io/include/rosflight_io/mavrosflight/mavlink_comm.hpp
+++ b/rosflight_io/include/rosflight_io/mavrosflight/mavlink_comm.hpp
@@ -102,13 +102,13 @@ protected:
   virtual void do_open() = 0;
   virtual void do_close() = 0;
   virtual void
-  do_async_read(const boost::asio::mutable_buffers_1 & buffer,
+  do_async_read(const boost::asio::mutable_buffer & buffer,
                 boost::function<void(const boost::system::error_code &, size_t)> handler) = 0;
   virtual void
-  do_async_write(const boost::asio::const_buffers_1 & buffer,
+  do_async_write(const boost::asio::const_buffer & buffer,
                  boost::function<void(const boost::system::error_code &, size_t)> handler) = 0;
 
-  boost::asio::io_service io_service_; //!< boost io service provider
+  boost::asio::io_context io_context_; //!< boost io context provider
 
 private:
   //===========================================================================

--- a/rosflight_io/include/rosflight_io/mavrosflight/mavlink_serial.hpp
+++ b/rosflight_io/include/rosflight_io/mavrosflight/mavlink_serial.hpp
@@ -74,7 +74,7 @@ private:
    * \brief Initiate an asynchronous read operation
    */
   void
-  do_async_read(const boost::asio::mutable_buffers_1 & buffer,
+  do_async_read(const boost::asio::mutable_buffer & buffer,
                 boost::function<void(const boost::system::error_code &, size_t)> handler) override;
 
   /**
@@ -82,7 +82,7 @@ private:
    * \param check_write_state If true, only start another write operation if a write sequence is not already running
    */
   void
-  do_async_write(const boost::asio::const_buffers_1 & buffer,
+  do_async_write(const boost::asio::const_buffer & buffer,
                  boost::function<void(const boost::system::error_code &, size_t)> handler) override;
 
   //===========================================================================

--- a/rosflight_io/include/rosflight_io/mavrosflight/mavlink_udp.hpp
+++ b/rosflight_io/include/rosflight_io/mavrosflight/mavlink_udp.hpp
@@ -73,10 +73,10 @@ private:
   void do_open() override;
   void do_close() override;
   void
-  do_async_read(const boost::asio::mutable_buffers_1 & buffer,
+  do_async_read(const boost::asio::mutable_buffer & buffer,
                 boost::function<void(const boost::system::error_code &, size_t)> handler) override;
   void
-  do_async_write(const boost::asio::const_buffers_1 & buffer,
+  do_async_write(const boost::asio::const_buffer & buffer,
                  boost::function<void(const boost::system::error_code &, size_t)> handler) override;
 
   //===========================================================================

--- a/rosflight_io/package.xml
+++ b/rosflight_io/package.xml
@@ -20,7 +20,6 @@
 
   <!-- ROS packages -->
   <depend>rclcpp</depend>
-  <depend>eigen_stl_containers</depend>
   <depend>geometry_msgs</depend>
   <depend>rosflight_msgs</depend>
   <depend>sensor_msgs</depend>
@@ -36,7 +35,6 @@
   <depend>yaml-cpp</depend>
 
   <build_depend>git</build_depend>
-  <build_depend>pkg-config</build_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rosflight_io/src/magnetometer_calibration.cpp
+++ b/rosflight_io/src/magnetometer_calibration.cpp
@@ -19,7 +19,10 @@ Eigen::VectorXd MagnetometerCalibrator::ellipsoid_least_squares(Eigen::MatrixXd 
   A.col(8) = z;
   A.col(9) = Eigen::VectorXd::Ones(x.rows());
   
-  Eigen::JacobiSVD<Eigen::MatrixXd> svd(A, Eigen::FullPivHouseholderQRPreconditioner | Eigen::ComputeFullU | Eigen::ComputeFullV);
+  auto flags = static_cast<unsigned int>(Eigen::FullPivHouseholderQRPreconditioner)
+    | static_cast<unsigned int>(Eigen::ComputeFullU)
+    | static_cast<unsigned int>(Eigen::ComputeFullV);
+  Eigen::JacobiSVD<Eigen::MatrixXd> svd(A, flags);
   
   Eigen::MatrixXd V = svd.matrixV();
 

--- a/rosflight_io/src/mavrosflight/mavlink_comm.cpp
+++ b/rosflight_io/src/mavrosflight/mavlink_comm.cpp
@@ -41,7 +41,7 @@ namespace mavrosflight
 using boost::asio::serial_port_base;
 
 MavlinkComm::MavlinkComm()
-    : io_service_()
+    : io_context_()
     , read_buf_raw_()
     , msg_in_()
     , status_in_()
@@ -57,14 +57,14 @@ void MavlinkComm::open()
 
   // start reading from the port
   async_read();
-  io_thread_ = boost::thread(boost::bind(&boost::asio::io_service::run, &this->io_service_));
+  io_thread_ = boost::thread(boost::bind(&boost::asio::io_context::run, &this->io_context_));
 }
 
 void MavlinkComm::close()
 {
   mutex_lock lock(mutex_);
 
-  io_service_.stop();
+  io_context_.stop();
   do_close();
 
   if (io_thread_.joinable()) {

--- a/rosflight_io/src/mavrosflight/mavlink_serial.cpp
+++ b/rosflight_io/src/mavrosflight/mavlink_serial.cpp
@@ -43,7 +43,7 @@ using boost::asio::serial_port_base;
 
 MavlinkSerial::MavlinkSerial(std::string port, int baud_rate)
     : MavlinkComm()
-    , serial_port_(io_service_)
+    , serial_port_(io_context_)
     , port_(std::move(port))
     , baud_rate_(baud_rate)
 {}
@@ -69,14 +69,14 @@ void MavlinkSerial::do_open()
 void MavlinkSerial::do_close() { serial_port_.close(); }
 
 void MavlinkSerial::do_async_read(
-  const boost::asio::mutable_buffers_1 & buffer,
+  const boost::asio::mutable_buffer & buffer,
   boost::function<void(const boost::system::error_code &, size_t)> handler)
 {
   serial_port_.async_read_some(buffer, handler);
 }
 
 void MavlinkSerial::do_async_write(
-  const boost::asio::const_buffers_1 & buffer,
+  const boost::asio::const_buffer & buffer,
   boost::function<void(const boost::system::error_code &, size_t)> handler)
 {
   serial_port_.async_write_some(buffer, handler);

--- a/rosflight_io/src/mavrosflight/mavlink_udp.cpp
+++ b/rosflight_io/src/mavrosflight/mavlink_udp.cpp
@@ -50,7 +50,7 @@ MavlinkUDP::MavlinkUDP(std::string bind_host, uint16_t bind_port, std::string re
     , bind_port_(bind_port)
     , remote_host_(std::move(remote_host))
     , remote_port_(remote_port)
-    , socket_(io_service_)
+    , socket_(io_context_)
 {}
 
 MavlinkUDP::~MavlinkUDP() { MavlinkUDP::do_close(); }
@@ -60,12 +60,12 @@ bool MavlinkUDP::is_open() { return socket_.is_open(); }
 void MavlinkUDP::do_open()
 {
   try {
-    udp::resolver resolver(io_service_);
+    udp::resolver resolver(io_context_);
 
-    bind_endpoint_ = *resolver.resolve({udp::v4(), bind_host_, ""});
+    bind_endpoint_ = resolver.resolve(udp::v4(), bind_host_, "").begin()->endpoint();
     bind_endpoint_.port(bind_port_);
 
-    remote_endpoint_ = *resolver.resolve({udp::v4(), remote_host_, ""});
+    remote_endpoint_ = resolver.resolve(udp::v4(), remote_host_, "").begin()->endpoint();
     remote_endpoint_.port(remote_port_);
 
     socket_.open(udp::v4());
@@ -82,14 +82,14 @@ void MavlinkUDP::do_open()
 void MavlinkUDP::do_close() { socket_.close(); }
 
 void MavlinkUDP::do_async_read(
-  const boost::asio::mutable_buffers_1 & buffer,
+  const boost::asio::mutable_buffer & buffer,
   boost::function<void(const boost::system::error_code &, size_t)> handler)
 {
   socket_.async_receive_from(buffer, remote_endpoint_, handler);
 }
 
 void MavlinkUDP::do_async_write(
-  const boost::asio::const_buffers_1 & buffer,
+  const boost::asio::const_buffer & buffer,
   boost::function<void(const boost::system::error_code &, size_t)> handler)
 {
   socket_.async_send_to(buffer, remote_endpoint_, handler);

--- a/rosflight_io/src/rosflight_io.cpp
+++ b/rosflight_io/src/rosflight_io.cpp
@@ -977,8 +977,9 @@ bool ROSflightIO::paramSetSrvCallback(
   return true;
 }
 
-bool ROSflightIO::paramWriteSrvCallback(const std_srvs::srv::Trigger::Request::SharedPtr & req,
-                                        const std_srvs::srv::Trigger::Response::SharedPtr & res)
+bool ROSflightIO::paramWriteSrvCallback(
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr & req,
+  const std_srvs::srv::Trigger::Response::SharedPtr & res)
 {
   res->success = mavrosflight_->param.write_params();
   if (!res->success) {
@@ -1005,7 +1006,7 @@ bool ROSflightIO::paramLoadFromFileCallback(
 }
 
 bool ROSflightIO::calibrateImuBiasSrvCallback(
-  const std_srvs::srv::Trigger::Request::SharedPtr & req,
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr & req,
   const std_srvs::srv::Trigger::Response::SharedPtr & res)
 {
   mavlink_message_t msg;
@@ -1017,7 +1018,7 @@ bool ROSflightIO::calibrateImuBiasSrvCallback(
 }
 
 bool ROSflightIO::calibrateRCTrimSrvCallback(
-  const std_srvs::srv::Trigger::Request::SharedPtr & req,
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr & req,
   const std_srvs::srv::Trigger::Response::SharedPtr & res)
 {
   mavlink_message_t msg;
@@ -1075,7 +1076,7 @@ void ROSflightIO::check_error_code(uint8_t current, uint8_t previous, ROSFLIGHT_
 }
 
 bool ROSflightIO::calibrateAirspeedSrvCallback(
-  const std_srvs::srv::Trigger::Request::SharedPtr & req,
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr & req,
   const std_srvs::srv::Trigger::Response::SharedPtr & res)
 {
   mavlink_message_t msg;
@@ -1085,8 +1086,9 @@ bool ROSflightIO::calibrateAirspeedSrvCallback(
   return true;
 }
 
-bool ROSflightIO::calibrateBaroSrvCallback(const std_srvs::srv::Trigger::Request::SharedPtr & req,
-                                           const std_srvs::srv::Trigger::Response::SharedPtr & res)
+bool ROSflightIO::calibrateBaroSrvCallback(
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr & req,
+  const std_srvs::srv::Trigger::Response::SharedPtr & res)
 {
   mavlink_message_t msg;
   mavlink_msg_rosflight_cmd_pack(1, 50, &msg, ROSFLIGHT_CMD_BARO_CALIBRATION);
@@ -1096,7 +1098,7 @@ bool ROSflightIO::calibrateBaroSrvCallback(const std_srvs::srv::Trigger::Request
 }
 
 bool ROSflightIO::calibrateMagSrvCallback(
-  const std_srvs::srv::Trigger::Request::SharedPtr & req,
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr & req,
   const std_srvs::srv::Trigger::Response::SharedPtr & res) {
  
   // Reset the mag compensation to get a clean calibration.
@@ -1162,8 +1164,9 @@ void ROSflightIO::calibrateMag() {
   }
 }
 
-bool ROSflightIO::rebootSrvCallback(const std_srvs::srv::Trigger::Request::SharedPtr & req,
-                                    const std_srvs::srv::Trigger::Response::SharedPtr & res)
+bool ROSflightIO::rebootSrvCallback(
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr & req,
+  const std_srvs::srv::Trigger::Response::SharedPtr & res)
 {
   mavlink_message_t msg;
   mavlink_msg_rosflight_cmd_pack(1, 50, &msg, ROSFLIGHT_CMD_REBOOT);
@@ -1173,7 +1176,7 @@ bool ROSflightIO::rebootSrvCallback(const std_srvs::srv::Trigger::Request::Share
 }
 
 bool ROSflightIO::rebootToBootloaderSrvCallback(
-  const std_srvs::srv::Trigger::Request::SharedPtr & req,
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr & req,
   const std_srvs::srv::Trigger::Response::SharedPtr & res)
 {
   mavlink_message_t msg;
@@ -1184,7 +1187,7 @@ bool ROSflightIO::rebootToBootloaderSrvCallback(
 }
 
 bool ROSflightIO::checkIfAllParamsReceivedCallback(
-  const std_srvs::srv::Trigger::Request::SharedPtr & req,
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr & req,
   const std_srvs::srv::Trigger::Response::SharedPtr & res)
 {
   res->success = mavrosflight_->param.got_all_params();
@@ -1196,7 +1199,7 @@ bool ROSflightIO::checkIfAllParamsReceivedCallback(
 }
 
 bool ROSflightIO::printMixingMatrixCallback(
-  const std_srvs::srv::Trigger::Request::SharedPtr & req,
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr & req,
   const std_srvs::srv::Trigger::Response::SharedPtr & res)
 {
   res->success = log_mixer_params();

--- a/rosflight_io/src/rosflight_io.cpp
+++ b/rosflight_io/src/rosflight_io.cpp
@@ -48,8 +48,6 @@
 #include <rosflight_io/mavrosflight/mavlink_udp.hpp>
 #include <rosflight_io/mavrosflight/serial_exception.hpp>
 #include <string>
-#include <tf2/LinearMath/Matrix3x3.h> // Swap to Eigen!
-#include <tf2/LinearMath/Quaternion.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <sys/resource.h>
 

--- a/rosflight_msgs/CMakeLists.txt
+++ b/rosflight_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20...3.28)
 project(rosflight_msgs)
 
 if(NOT CMAKE_C_STANDARD)

--- a/rosflight_msgs/CMakeLists.txt
+++ b/rosflight_msgs/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
-endif(NOT CMAKE_BUILD_TYPE)
+endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
@@ -35,7 +35,7 @@ set(msg_files
   "msg/RGBCamera.msg"
   "msg/Status.msg"
   "msg/SimState.msg"
-  )
+)
 
 # declare the service files to generate code for
 set(srv_files
@@ -43,7 +43,7 @@ set(srv_files
   "srv/ParamGet.srv"
   "srv/ParamSet.srv"
   "srv/SetSimState.srv"
-  )
+)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
@@ -52,7 +52,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   builtin_interfaces
   geometry_msgs
   std_msgs
-  )
+)
 
 ament_export_dependencies(rosidl_default_runtime)
 

--- a/rosflight_pkgs/CMakeLists.txt
+++ b/rosflight_pkgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20...3.28)
 project(rosflight_pkgs)
 find_package(ament_cmake REQUIRED)
 ament_package()

--- a/rosflight_rqt_plugins/setup.py
+++ b/rosflight_rqt_plugins/setup.py
@@ -28,7 +28,6 @@ setup(
     keywords=['ROSflight', 'rqt'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: BSD',
         'Programming Language :: Python',
         'Topic :: Ground Control Stations',
     ],

--- a/rosflight_sim/CMakeLists.txt
+++ b/rosflight_sim/CMakeLists.txt
@@ -87,6 +87,10 @@ add_library(rosflight_firmware
 )
 target_include_directories(rosflight_firmware PRIVATE ${FIRMWARE_INCLUDE_DIRS})
 target_link_libraries(rosflight_firmware PRIVATE Eigen3::Eigen)
+# FIXME: Eigen currently prints a maybe-uninitialized warning for the invert_mixer()
+# function in mixer.cpp and this disables the warning. This warning may be fixed
+# in a future version of Eigen and the flag could be removed.
+target_compile_options(rosflight_firmware PRIVATE -Wno-maybe-uninitialized)
 target_compile_definitions(rosflight_firmware PUBLIC
   GIT_VERSION_HASH=0x${GIT_VERSION_HASH}
   GIT_VERSION_STRING=\"${GIT_VERSION_STRING}\"

--- a/rosflight_sim/CMakeLists.txt
+++ b/rosflight_sim/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(std_srvs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(rosflight_msgs REQUIRED)
 find_package(Eigen3 REQUIRED)
-find_package(Boost REQUIRED COMPONENTS system thread)
+find_package(Boost CONFIG REQUIRED COMPONENTS thread)
 
 
 ##############
@@ -108,7 +108,6 @@ install(
 
 include_directories(include
   ${SDFormat_INCLUDE_DIRS}
-  ${Boost_INCLUDE_DIRS}
 )
 
 ##################
@@ -143,7 +142,7 @@ target_link_libraries(sil_board PRIVATE
   std_srvs::std_srvs
   sensor_msgs::sensor_msgs
   rosflight_msgs::rosflight_msgs
-  ${Boost_LIBRARIES}
+  Boost::thread
 )
 install(
   TARGETS sil_board

--- a/rosflight_sim/CMakeLists.txt
+++ b/rosflight_sim/CMakeLists.txt
@@ -12,7 +12,7 @@ add_compile_options(-Wall -fPIC)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
-endif(NOT CMAKE_BUILD_TYPE)
+endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
@@ -34,8 +34,8 @@ set(FIRMWARE_SUBMODULE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../rosflight_firmware")
 if(NOT EXISTS "${FIRMWARE_SUBMODULE_DIR}/.git")
   message(STATUS "Firmware submodule not found at ${FIRMWARE_SUBMODULE_DIR}")
   execute_process(
-          COMMAND git submodule update --init --recursive
-          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMAND git submodule update --init --recursive
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   )
 endif()
 
@@ -52,15 +52,19 @@ include_directories(
 )
 
 # Git information
-execute_process(COMMAND git rev-parse --short=8 HEAD
-        OUTPUT_VARIABLE GIT_VERSION_HASH
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/rosflight_firmware)
+execute_process(
+  COMMAND git rev-parse --short=8 HEAD
+  OUTPUT_VARIABLE GIT_VERSION_HASH
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/rosflight_firmware
+)
 
-execute_process(COMMAND git describe --tags --abbrev=8 --always --dirty --long
-        OUTPUT_VARIABLE GIT_VERSION_STRING
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/rosflight_firmware)
+execute_process(
+  COMMAND git describe --tags --abbrev=8 --always --dirty --long
+  OUTPUT_VARIABLE GIT_VERSION_STRING
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/rosflight_firmware
+)
 
 if("${GIT_VERSION_STRING}" STREQUAL "")
   set(GIT_VERSION_STRING "undefined")
@@ -119,10 +123,8 @@ include_directories(include
 ##################
 
 # ROSflightSIL
-add_executable(rosflight_sil_manager
-  src/rosflight_sil.cpp)
-target_include_directories(rosflight_sil_manager
-  PRIVATE include)
+add_executable(rosflight_sil_manager src/rosflight_sil.cpp)
+target_include_directories(rosflight_sil_manager PRIVATE include)
 target_link_libraries(rosflight_sil_manager PRIVATE
   rclcpp::rclcpp
   std_srvs::std_srvs
@@ -136,10 +138,9 @@ install(
 add_executable(sil_board
   src/sil_board_ros.cpp
   src/sil_board.cpp
-  src/udp_board.cpp)
-target_include_directories(sil_board
-  PRIVATE
-    include)
+  src/udp_board.cpp
+)
+target_include_directories(sil_board PRIVATE include)
 target_link_libraries(sil_board PRIVATE
   rosflight_firmware
   rclcpp::rclcpp
@@ -150,7 +151,8 @@ target_link_libraries(sil_board PRIVATE
 )
 install(
   TARGETS sil_board
-  DESTINATION lib/${PROJECT_NAME})
+  DESTINATION lib/${PROJECT_NAME}
+)
 
 # Standalone simulator
 add_subdirectory(simulators/standalone_sim)

--- a/rosflight_sim/CMakeLists.txt
+++ b/rosflight_sim/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20...3.28)
 project(rosflight_sim)
 
 if(NOT CMAKE_C_STANDARD)

--- a/rosflight_sim/CMakeLists.txt
+++ b/rosflight_sim/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(rclpy REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(rosflight_msgs REQUIRED)
+find_package(rosflight_compat REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(Boost CONFIG REQUIRED COMPONENTS thread)
 
@@ -129,6 +130,7 @@ target_link_libraries(rosflight_sil_manager PRIVATE
   rclcpp::rclcpp
   std_srvs::std_srvs
   rosflight_msgs::rosflight_msgs
+  rosflight_compat::compat_headers
 )
 install(
   TARGETS rosflight_sil_manager

--- a/rosflight_sim/CMakeLists.txt
+++ b/rosflight_sim/CMakeLists.txt
@@ -43,8 +43,8 @@ set(FIRMWARE_INCLUDE_DIRS
   ../rosflight_firmware/include/
   ../rosflight_firmware/include/interface/
   ../rosflight_firmware/lib/
-  ../rosflight_firmware/comms/
-  ../rosflight_firmware/test/
+  ../rosflight_firmware/comms/mavlink
+  ../rosflight_firmware/comms/mavlink/v1.0
 )
 
 include_directories(
@@ -86,7 +86,7 @@ add_library(rosflight_firmware
   ${FIRMWARE_SUBMODULE_DIR}/lib/turbomath/turbomath.cpp
 )
 target_include_directories(rosflight_firmware PRIVATE ${FIRMWARE_INCLUDE_DIRS})
-target_link_libraries(rosflight_firmware Eigen3::Eigen)
+target_link_libraries(rosflight_firmware PRIVATE Eigen3::Eigen)
 target_compile_definitions(rosflight_firmware PUBLIC
   GIT_VERSION_HASH=0x${GIT_VERSION_HASH}
   GIT_VERSION_STRING=\"${GIT_VERSION_STRING}\"
@@ -107,9 +107,6 @@ install(
 ###################
 
 include_directories(include
-  ${ament_INCLUDE_DIRS}
-  ${rclcpp_INLCUDE_DIRS}
-  ${Eigen_INCLUDE_DIRS}
   ${SDFormat_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIRS}
 )
@@ -123,7 +120,11 @@ add_executable(rosflight_sil_manager
   src/rosflight_sil.cpp)
 target_include_directories(rosflight_sil_manager
   PRIVATE include)
-ament_target_dependencies(rosflight_sil_manager rclcpp std_srvs rosflight_msgs)
+target_link_libraries(rosflight_sil_manager PRIVATE
+  rclcpp::rclcpp
+  std_srvs::std_srvs
+  rosflight_msgs::rosflight_msgs
+)
 install(
   TARGETS rosflight_sil_manager
   DESTINATION lib/${PROJECT_NAME})
@@ -133,13 +134,17 @@ add_executable(sil_board
   src/sil_board_ros.cpp
   src/sil_board.cpp
   src/udp_board.cpp)
-target_link_libraries(sil_board
-  rosflight_firmware
-  ${Boost_LIBRARIES})
 target_include_directories(sil_board
   PRIVATE
     include)
-ament_target_dependencies(sil_board rclcpp std_srvs sensor_msgs rosflight_msgs)
+target_link_libraries(sil_board PRIVATE
+  rosflight_firmware
+  rclcpp::rclcpp
+  std_srvs::std_srvs
+  sensor_msgs::sensor_msgs
+  rosflight_msgs::rosflight_msgs
+  ${Boost_LIBRARIES}
+)
 install(
   TARGETS sil_board
   DESTINATION lib/${PROJECT_NAME})

--- a/rosflight_sim/include/rosflight_sim/forces_and_moments_interface.hpp
+++ b/rosflight_sim/include/rosflight_sim/forces_and_moments_interface.hpp
@@ -36,9 +36,6 @@
 #ifndef ROSFLIGHT_SIM_MAV_FORCES_AND_MOMENTS_H
 #define ROSFLIGHT_SIM_MAV_FORCES_AND_MOMENTS_H
 
-#include <chrono>
-#include <future>
-
 #include <Eigen/Dense>
 #include <Eigen/SVD>
 #include <geometry_msgs/msg/wrench_stamped.hpp>

--- a/rosflight_sim/include/rosflight_sim/udp_board.hpp
+++ b/rosflight_sim/include/rosflight_sim/udp_board.hpp
@@ -110,7 +110,7 @@ private:
   boost::recursive_mutex write_mutex_;
   boost::recursive_mutex read_mutex_;
 
-  boost::asio::io_service io_service_;
+  boost::asio::io_context io_context_;
 
   boost::asio::ip::udp::socket socket_;
   boost::asio::ip::udp::endpoint bind_endpoint_;

--- a/rosflight_sim/include/rosflight_sim/udp_board.hpp
+++ b/rosflight_sim/include/rosflight_sim/udp_board.hpp
@@ -44,7 +44,7 @@
 #include <boost/thread.hpp>
 
 #include "board.h"
-#include "mavlink/mavlink.h"
+#include "mavlink.h"
 
 namespace rosflight_sim
 {

--- a/rosflight_sim/launch/fixedwing_init_firmware.launch.py
+++ b/rosflight_sim/launch/fixedwing_init_firmware.launch.py
@@ -6,52 +6,55 @@ Last Modified: July 17, 2023
 Description: ROS2 launch file used to load parameters and call services needed for initializing firmware for fixedwings.
 """
 
-import os
-
-from ament_index_python import get_package_share_directory
+from ament_index_python.packages import get_package_share_path
 from launch import LaunchDescription
-from launch.actions import ExecuteProcess
+from launch.actions import ExecuteProcess, TimerAction
 from launch.substitutions import FindExecutable
 
 
 def generate_launch_description():
     """Initialized rosflight firmware for flying a fixedwing UAV in the sim"""
 
+    rosflight_sim = get_package_share_path("rosflight_sim")
+    param_file = rosflight_sim / "params" / "fixedwing_firmware.yaml"
+
     # Call load parameter file service
     param_load_service_exec = ExecuteProcess(
-        cmd=[[
-            FindExecutable(name='ros2'),
-            ' service call ',
-            '/param_load_from_file ',
-            'rosflight_msgs/srv/ParamFile ',
-            '"{filename: "' + os.path.join(
-                get_package_share_directory('rosflight_sim'), 'params/fixedwing_firmware.yaml"}'
-            ) + '"'
-        ]],
-        shell=True
+        cmd=[
+            FindExecutable(name="ros2"),
+            "service",
+            "call",
+            "/param_load_from_file",
+            "rosflight_msgs/srv/ParamFile",
+            f"{{filename: {param_file}}}",
+        ],
     )
 
     # Call calibrate IMU service
     imu_cal_service_exec = ExecuteProcess(
-        cmd=[[
-            FindExecutable(name='ros2'),
-            ' service call ',
-            '/calibrate_imu ',
-            'std_srvs/srv/Trigger '
-        ]],
-        shell=True
+        cmd=[
+            FindExecutable(name="ros2"),
+            "service",
+            "call",
+            "/calibrate_imu",
+            "std_srvs/srv/Trigger",
+        ],
     )
 
     # Save params
-    write_params_service_exec = ExecuteProcess(
-        cmd=[[
-            'sleep 10 ; ',
-            FindExecutable(name='ros2'),
-            ' service call ',
-            '/param_write ',
-            'std_srvs/srv/Trigger '
-        ]],
-        shell=True
+    write_params_service_exec = TimerAction(
+        period=10.0,
+        actions=[
+            ExecuteProcess(
+                cmd=[
+                    FindExecutable(name="ros2"),
+                    "service",
+                    "call",
+                    "/param_write",
+                    "std_srvs/srv/Trigger",
+                ],
+            )
+        ],
     )
 
     return LaunchDescription([

--- a/rosflight_sim/launch/multirotor_init_firmware.launch.py
+++ b/rosflight_sim/launch/multirotor_init_firmware.launch.py
@@ -6,52 +6,55 @@ Last Modified: July 17, 2023
 Description: ROS2 launch file used to load parameters and call services needed for initializing firmware for multirotors.
 """
 
-import os
-
-from ament_index_python import get_package_share_directory
+from ament_index_python.packages import get_package_share_path
 from launch import LaunchDescription
-from launch.actions import ExecuteProcess
+from launch.actions import ExecuteProcess, TimerAction
 from launch.substitutions import FindExecutable
 
 
 def generate_launch_description():
     """Initialized rosflight firmware for flying a multirotor UAV in the sim"""
 
+    rosflight_sim = get_package_share_path("rosflight_sim")
+    param_file = rosflight_sim / "params" / "multirotor_firmware" / "multirotor_combined.yaml"
+
     # Call load parameter file service
     param_load_service_exec = ExecuteProcess(
-        cmd=[[
-            FindExecutable(name='ros2'),
-            ' service call ',
-            '/param_load_from_file ',
-            'rosflight_msgs/srv/ParamFile ',
-            '"{filename: "' + os.path.join(
-                get_package_share_directory('rosflight_sim'), 'params/multirotor_firmware/multirotor_combined.yaml"}'
-            ) + '"'
-        ]],
-        shell=True
+        cmd=[
+            FindExecutable(name="ros2"),
+            "service",
+            "call",
+            "/param_load_from_file",
+            "rosflight_msgs/srv/ParamFile",
+            f"{{filename: {param_file}}}",
+        ],
     )
 
     # Call calibrate IMU service
     imu_cal_service_exec = ExecuteProcess(
-        cmd=[[
-            FindExecutable(name='ros2'),
-            ' service call ',
-            '/calibrate_imu ',
-            'std_srvs/srv/Trigger '
-        ]],
-        shell=True
+        cmd=[
+            FindExecutable(name="ros2"),
+            "service",
+            "call",
+            "/calibrate_imu",
+            "std_srvs/srv/Trigger",
+        ],
     )
 
     # Save params
-    write_params_service_exec = ExecuteProcess(
-        cmd=[[
-            'sleep 10 ; ',
-            FindExecutable(name='ros2'),
-            ' service call ',
-            '/param_write ',
-            'std_srvs/srv/Trigger '
-        ]],
-        shell=True
+    write_params_service_exec = TimerAction(
+        period=10.0,
+        actions=[
+            ExecuteProcess(
+                cmd=[
+                    FindExecutable(name="ros2"),
+                    "service",
+                    "call",
+                    "/param_write",
+                    "std_srvs/srv/Trigger",
+                ],
+            )
+        ],
     )
 
     return LaunchDescription([

--- a/rosflight_sim/package.xml
+++ b/rosflight_sim/package.xml
@@ -28,6 +28,7 @@
   <depend>tf2_geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rosflight_msgs</depend>
+  <depend>rosflight_compat</depend>
   <depend>python3-pygame</depend>
   <depend>eigen</depend>
 

--- a/rosflight_sim/package.xml
+++ b/rosflight_sim/package.xml
@@ -25,6 +25,7 @@
   <depend>rclpy</depend>
 
   <depend>geometry_msgs</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>nav_msgs</depend>
   <depend>rosflight_msgs</depend>
   <depend>python3-pygame</depend>

--- a/rosflight_sim/simulators/standalone_sim/CMakeLists.txt
+++ b/rosflight_sim/simulators/standalone_sim/CMakeLists.txt
@@ -28,11 +28,8 @@ find_package(tf2_ros REQUIRED)
 find_package(visualization_msgs REQUIRED)
 
 # Rosflight Standalone sim
-add_executable(standalone_viz_transcriber
-  src/standalone_viz_transcriber.cpp)
-target_include_directories(standalone_viz_transcriber
-  PRIVATE
-    include)
+add_executable(standalone_viz_transcriber src/standalone_viz_transcriber.cpp)
+target_include_directories(standalone_viz_transcriber PRIVATE include)
 target_link_libraries(standalone_viz_transcriber PRIVATE
   ament_index_cpp::ament_index_cpp
   rclcpp::rclcpp
@@ -48,35 +45,40 @@ ament_export_dependencies(rclcpp
   tf2_ros
   geometry_msgs
   rosflight_msgs
-  visualization_msgs)
+  visualization_msgs
+)
 install(
   TARGETS standalone_viz_transcriber
-  DESTINATION lib/${PROJECT_NAME})
+  DESTINATION lib/${PROJECT_NAME}
+)
 
 # Time Manager
 add_executable(standalone_time_manager
   ../../src/time_manager_interface.cpp
-  src/standalone_time_manager.cpp)
-target_include_directories(standalone_time_manager
-  PRIVATE
-    ../../include
-    include)
+  src/standalone_time_manager.cpp
+)
+target_include_directories(standalone_time_manager PRIVATE
+  ../../include
+  include
+)
 target_link_libraries(standalone_time_manager PRIVATE
   rclcpp::rclcpp
   std_srvs::std_srvs
 )
 install(
   TARGETS standalone_time_manager
-  DESTINATION lib/${PROJECT_NAME})
+  DESTINATION lib/${PROJECT_NAME}
+)
 
 # Multirotor Forces And Moments
 add_executable(multirotor_forces_and_moments
   ../../src/forces_and_moments_interface.cpp
-  src/multirotor_forces_and_moments.cpp)
-target_include_directories(multirotor_forces_and_moments
-  PRIVATE
-    ../../include
-    include)
+  src/multirotor_forces_and_moments.cpp
+)
+target_include_directories(multirotor_forces_and_moments PRIVATE
+  ../../include
+  include
+)
 target_link_libraries(multirotor_forces_and_moments PRIVATE
   rclcpp::rclcpp
   std_srvs::std_srvs
@@ -86,16 +88,18 @@ target_link_libraries(multirotor_forces_and_moments PRIVATE
 )
 install(
   TARGETS multirotor_forces_and_moments
-  DESTINATION lib/${PROJECT_NAME})
+  DESTINATION lib/${PROJECT_NAME}
+)
 
 # FixedWing Forces And Moments
 add_executable(fixedwing_forces_and_moments
   ../../src/forces_and_moments_interface.cpp
-  src/fixedwing_forces_and_moments.cpp)
-target_include_directories(fixedwing_forces_and_moments
-  PRIVATE
-    ../../include
-    include)
+  src/fixedwing_forces_and_moments.cpp
+)
+target_include_directories(fixedwing_forces_and_moments PRIVATE
+  ../../include
+  include
+)
 target_link_libraries(fixedwing_forces_and_moments PRIVATE
   rclcpp::rclcpp
   std_srvs::std_srvs
@@ -105,16 +109,18 @@ target_link_libraries(fixedwing_forces_and_moments PRIVATE
 )
 install(
   TARGETS fixedwing_forces_and_moments
-  DESTINATION lib/${PROJECT_NAME})
+  DESTINATION lib/${PROJECT_NAME}
+)
 
 # Standalone Sensors
 add_executable(standalone_sensors
   ../../src/sensor_interface.cpp
-  src/standalone_sensors.cpp)
-target_include_directories(standalone_sensors
-  PRIVATE
-    include
-    simulators/standalone_sim/include)
+  src/standalone_sensors.cpp
+)
+target_include_directories(standalone_sensors PRIVATE
+  include
+  simulators/standalone_sim/include
+)
 target_link_libraries(standalone_sensors PRIVATE
   rclcpp::rclcpp
   sensor_msgs::sensor_msgs
@@ -124,16 +130,18 @@ target_link_libraries(standalone_sensors PRIVATE
 )
 install(
   TARGETS standalone_sensors
-  DESTINATION lib/${PROJECT_NAME})
+  DESTINATION lib/${PROJECT_NAME}
+)
 
 # Dynamics
 add_executable(standalone_dynamics
   ../../src/dynamics_interface.cpp
-  src/standalone_dynamics.cpp)
-target_include_directories(standalone_dynamics
-  PRIVATE
-    ../../include
-    include)
+  src/standalone_dynamics.cpp
+)
+target_include_directories(standalone_dynamics PRIVATE
+  ../../include
+  include
+)
 target_link_libraries(standalone_dynamics PRIVATE
   rclcpp::rclcpp
   rosflight_msgs::rosflight_msgs
@@ -147,10 +155,12 @@ ament_export_dependencies(standalone_dynamics
   tf2_geometry_msgs
   std_srvs
   rclcpp
-  rosflight_msgs)
+  rosflight_msgs
+)
 install(
   TARGETS standalone_dynamics
-  DESTINATION lib/${PROJECT_NAME})
+  DESTINATION lib/${PROJECT_NAME}
+)
 
 
 # Other install

--- a/rosflight_sim/simulators/standalone_sim/CMakeLists.txt
+++ b/rosflight_sim/simulators/standalone_sim/CMakeLists.txt
@@ -80,6 +80,7 @@ target_include_directories(multirotor_forces_and_moments PRIVATE
   include
 )
 target_link_libraries(multirotor_forces_and_moments PRIVATE
+rosflight_compat::compat_headers
   rclcpp::rclcpp
   std_srvs::std_srvs
   geometry_msgs::geometry_msgs
@@ -101,6 +102,7 @@ target_include_directories(fixedwing_forces_and_moments PRIVATE
   include
 )
 target_link_libraries(fixedwing_forces_and_moments PRIVATE
+  rosflight_compat::compat_headers
   rclcpp::rclcpp
   std_srvs::std_srvs
   geometry_msgs::geometry_msgs

--- a/rosflight_sim/simulators/standalone_sim/CMakeLists.txt
+++ b/rosflight_sim/simulators/standalone_sim/CMakeLists.txt
@@ -33,14 +33,16 @@ add_executable(standalone_viz_transcriber
 target_include_directories(standalone_viz_transcriber
   PRIVATE
     include)
-ament_target_dependencies(standalone_viz_transcriber
-  ament_index_cpp
-  geometry_msgs
-  rclcpp
-  rosflight_msgs
-  tf2
-  tf2_ros
-  visualization_msgs)
+target_link_libraries(standalone_viz_transcriber PRIVATE
+  ament_index_cpp::ament_index_cpp
+  rclcpp::rclcpp
+  geometry_msgs::geometry_msgs
+  rosflight_msgs::rosflight_msgs
+  tf2::tf2
+  tf2_ros::tf2_ros
+  tf2_geometry_msgs::tf2_geometry_msgs
+  visualization_msgs::visualization_msgs
+)
 ament_export_dependencies(rclcpp
   tf2
   tf2_ros
@@ -59,7 +61,10 @@ target_include_directories(standalone_time_manager
   PRIVATE
     ../../include
     include)
-ament_target_dependencies(standalone_time_manager rclcpp std_srvs)
+target_link_libraries(standalone_time_manager PRIVATE
+  rclcpp::rclcpp
+  std_srvs::std_srvs
+)
 install(
   TARGETS standalone_time_manager
   DESTINATION lib/${PROJECT_NAME})
@@ -72,12 +77,13 @@ target_include_directories(multirotor_forces_and_moments
   PRIVATE
     ../../include
     include)
-target_link_libraries(multirotor_forces_and_moments Eigen3::Eigen)
-ament_target_dependencies(multirotor_forces_and_moments
-  rclcpp
-  std_srvs
-  geometry_msgs
-  rosflight_msgs)
+target_link_libraries(multirotor_forces_and_moments PRIVATE
+  rclcpp::rclcpp
+  std_srvs::std_srvs
+  geometry_msgs::geometry_msgs
+  rosflight_msgs::rosflight_msgs
+  Eigen3::Eigen
+)
 install(
   TARGETS multirotor_forces_and_moments
   DESTINATION lib/${PROJECT_NAME})
@@ -90,12 +96,13 @@ target_include_directories(fixedwing_forces_and_moments
   PRIVATE
     ../../include
     include)
-target_link_libraries(fixedwing_forces_and_moments Eigen3::Eigen)
-ament_target_dependencies(fixedwing_forces_and_moments
-  rclcpp
-  std_srvs
-  geometry_msgs
-  rosflight_msgs)
+target_link_libraries(fixedwing_forces_and_moments PRIVATE
+  rclcpp::rclcpp
+  std_srvs::std_srvs
+  geometry_msgs::geometry_msgs
+  rosflight_msgs::rosflight_msgs
+  Eigen3::Eigen
+)
 install(
   TARGETS fixedwing_forces_and_moments
   DESTINATION lib/${PROJECT_NAME})
@@ -108,8 +115,13 @@ target_include_directories(standalone_sensors
   PRIVATE
     include
     simulators/standalone_sim/include)
-target_link_libraries(standalone_sensors Eigen3::Eigen)
-ament_target_dependencies(standalone_sensors rclcpp sensor_msgs rosflight_msgs geometry_msgs)
+target_link_libraries(standalone_sensors PRIVATE
+  rclcpp::rclcpp
+  sensor_msgs::sensor_msgs
+  rosflight_msgs::rosflight_msgs
+  geometry_msgs::geometry_msgs
+  Eigen3::Eigen
+)
 install(
   TARGETS standalone_sensors
   DESTINATION lib/${PROJECT_NAME})
@@ -122,14 +134,14 @@ target_include_directories(standalone_dynamics
   PRIVATE
     ../../include
     include)
-target_link_libraries(standalone_dynamics
-  Eigen3::Eigen)
-ament_target_dependencies(standalone_dynamics
-  geometry_msgs
-  tf2_geometry_msgs
-  std_srvs
-  rclcpp
-  rosflight_msgs)
+target_link_libraries(standalone_dynamics PRIVATE
+  rclcpp::rclcpp
+  rosflight_msgs::rosflight_msgs
+  geometry_msgs::geometry_msgs
+  tf2_geometry_msgs::tf2_geometry_msgs
+  std_srvs::std_srvs
+  Eigen3::Eigen
+)
 ament_export_dependencies(standalone_dynamics
   geometry_msgs
   tf2_geometry_msgs

--- a/rosflight_sim/simulators/standalone_sim/CMakeLists.txt
+++ b/rosflight_sim/simulators/standalone_sim/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20...3.28)
 # Don't define own project -- use parent instead
 
 if(NOT CMAKE_C_STANDARD)

--- a/rosflight_sim/simulators/standalone_sim/include/standalone_viz_transcriber.hpp
+++ b/rosflight_sim/simulators/standalone_sim/include/standalone_viz_transcriber.hpp
@@ -37,7 +37,7 @@
 #include <vector>
 
 #include <rclcpp/rclcpp.hpp>
-#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_ros/transform_broadcaster.hpp>
 #include <visualization_msgs/msg/marker.hpp>
 
 #include "rosflight_msgs/msg/sim_state.hpp"

--- a/rosflight_sim/simulators/standalone_sim/launch/common_nodes_standalone.launch.py
+++ b/rosflight_sim/simulators/standalone_sim/launch/common_nodes_standalone.launch.py
@@ -7,23 +7,19 @@ Description: ROS2 launch file used to launch all nodes that are both standalone 
     and frame-type independent.
 """
 
-import os
-import sys
-
-from ament_index_python import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import IncludeLaunchDescription, DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument
 from launch.conditions import IfCondition
-from launch.substitutions import LaunchConfiguration
-from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
     """This is a launch file that launches all nodes needed for a standalone simulation that do not depend on the standalone simulator"""
 
-    rosflight_sim_dir = get_package_share_directory('rosflight_sim')
-    param_file = os.path.join(rosflight_sim_dir, 'params', 'standalone_sim_params.yaml')
+    rosflight_sim_share = FindPackageShare('rosflight_sim')
+    param_file = PathJoinSubstitution([rosflight_sim_share, 'params', 'standalone_sim_params.yaml'])
 
     # Declare launch arguments
     use_sim_time_arg = DeclareLaunchArgument(

--- a/rosflight_sim/simulators/standalone_sim/launch/fixedwing_standalone.launch.py
+++ b/rosflight_sim/simulators/standalone_sim/launch/fixedwing_standalone.launch.py
@@ -6,22 +6,22 @@ Last Modified: March 25, 2025
 Description: ROS2 launch file used to launch all the nodes for a fixedwing standalone simulator
 """
 
-import os
-import sys
-
-from ament_index_python import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription, DeclareLaunchArgument
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
     """This is a launch file that runs the bare minimum requirements fly a fixedwing in a standalone simulator"""
+
+    rosflight_sim_share = FindPackageShare('rosflight_sim')
+
     dynamics_param_file_arg = DeclareLaunchArgument(
         "dynamics_param_file",
-        default_value=os.path.join(get_package_share_directory('rosflight_sim'), 'params', 'anaconda_dynamics.yaml'),
+        default_value=PathJoinSubstitution([rosflight_sim_share, 'params', 'anaconda_dynamics.yaml']),
         description="Parameter file that contains the dynamics of the vehicle, containing the vehicle mass parameter."
     )
     dynamics_param_file = LaunchConfiguration("dynamics_param_file")
@@ -40,23 +40,17 @@ def generate_launch_description():
 
     # Start simulator
     simulator_launch_include = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([
-            os.path.join(
-                get_package_share_directory("rosflight_sim"),
-                "launch/standalone_sim.launch.py",
-            )
-        ]),
-        launch_arguments={
-            'sim_aircraft_file': os.path.join("common_resource", "skyhunter.dae")
-        }.items()
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution([rosflight_sim_share, 'launch', 'standalone_sim.launch.py'])
+        ),
+        launch_arguments={'sim_aircraft_file': "common_resource/skyhunter.dae"}.items()
     )
 
     # Start common nodes
     common_nodes_include = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            os.path.join(
-                get_package_share_directory("rosflight_sim"),
-                "launch", "common_nodes_standalone.launch.py"
+            PathJoinSubstitution(
+                [rosflight_sim_share, 'launch', 'common_nodes_standalone.launch.py']
             )
         ),
         launch_arguments={

--- a/rosflight_sim/simulators/standalone_sim/launch/multirotor_standalone.launch.py
+++ b/rosflight_sim/simulators/standalone_sim/launch/multirotor_standalone.launch.py
@@ -6,85 +6,87 @@ Last Modified: March 25, 2025
 Description: ROS2 launch file used to launch all the nodes for a Multirotor standalone simulator
 """
 
-import os
-import sys
-
-from ament_index_python import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription, DeclareLaunchArgument
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
     """This is a launch file that runs the bare minimum requirements fly a multirotor in a standalone simulator"""
-    dynamics_param_file = os.path.join(get_package_share_directory('rosflight_sim'), 'params', 'multirotor_dynamics.yaml')
+
+    rosflight_sim_share = FindPackageShare("rosflight_sim")
+
+    dynamics_param_file = PathJoinSubstitution(
+        [rosflight_sim_share, "params", "multirotor_dynamics.yaml"]
+    )
 
     # Declare launch arguments
     use_sim_time_arg = DeclareLaunchArgument(
         "use_sim_time",
         default_value="false",
-        description="Whether the nodes will use sim time or not"
+        description="Whether the nodes will use sim time or not",
     )
-    use_sim_time = LaunchConfiguration('use_sim_time')
+    use_sim_time = LaunchConfiguration("use_sim_time")
 
     ##########
     # Launch #
     ##########
 
     # Start simulator
-    simulator_launch_include = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([
-            os.path.join(
-                get_package_share_directory("rosflight_sim"),
-                "launch/standalone_sim.launch.py",
-            )
-        ]),
-        launch_arguments={
-            'sim_aircraft_file': os.path.join("common_resource", "multirotor.dae")
-        }.items()
-    )
-
-    # Start common nodes
-    common_nodes_include = IncludeLaunchDescription(
+    simulator_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            os.path.join(
-                get_package_share_directory("rosflight_sim"),
-                "launch", "common_nodes_standalone.launch.py"
+            PathJoinSubstitution(
+                [rosflight_sim_share, "launch", "standalone_sim.launch.py"]
             )
         ),
         launch_arguments={
-            'use_sim_time': use_sim_time,
-            'dynamics_param_file': dynamics_param_file,
-        }.items()
+            "sim_aircraft_file": "common_resource/multirotor.dae",
+        }.items(),
+    )
+
+    # Start common nodes
+    common_nodes_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [
+                    rosflight_sim_share,
+                    "launch",
+                    "common_nodes_standalone.launch.py",
+                ]
+            )
+        ),
+        launch_arguments={
+            "use_sim_time": use_sim_time,
+            "dynamics_param_file": dynamics_param_file,
+        }.items(),
     )
 
     # Start forces and moments
     mr_forces_moments_node = Node(
         package="rosflight_sim",
         executable="multirotor_forces_and_moments",
-        name='multirotor_forces_and_moments',
+        name="multirotor_forces_and_moments",
         output="screen",
-        parameters=[
-            {"use_sim_time": use_sim_time}, dynamics_param_file
-        ],
+        parameters=[{"use_sim_time": use_sim_time}, dynamics_param_file],
     )
 
     # Start dynamics node
     standalone_dynamics_node = Node(
         package="rosflight_sim",
         executable="standalone_dynamics",
-        name='standalone_dynamics',
+        name="standalone_dynamics",
         output="screen",
-        parameters=[{"use_sim_time": use_sim_time}, dynamics_param_file]
+        parameters=[{"use_sim_time": use_sim_time}, dynamics_param_file],
     )
 
     return LaunchDescription(
         [
             use_sim_time_arg,
-            simulator_launch_include,
-            common_nodes_include,
+            simulator_launch,
+            common_nodes_launch,
             mr_forces_moments_node,
             standalone_dynamics_node,
         ]

--- a/rosflight_sim/simulators/standalone_sim/launch/standalone_sim.launch.py
+++ b/rosflight_sim/simulators/standalone_sim/launch/standalone_sim.launch.py
@@ -1,28 +1,29 @@
-import os
 from launch import LaunchDescription
-from launch.substitutions import TextSubstitution, LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
 from launch.actions import DeclareLaunchArgument
 from launch_ros.actions import Node
-from ament_index_python.packages import get_package_share_directory
 
 
 def generate_launch_description():
     # Create the package directory
-    rosflight_sim_share_dir = get_package_share_directory("rosflight_sim")
+    rosflight_sim_share = FindPackageShare('rosflight_sim')
 
     rviz2_config_file = LaunchConfiguration('rviz2_config_file')
     rviz2_config_file_arg = DeclareLaunchArgument(
         'rviz2_config_file',
-        default_value=TextSubstitution(text=os.path.join(rosflight_sim_share_dir, "config", "standalone_sim.rviz")),
+        default_value=PathJoinSubstitution([rosflight_sim_share, 'config', 'standalone_sim.rviz']),
         description="Path to the .rviz file that defines the RViz configuration."
     )
-    rviz2_splash_file = os.path.join(rosflight_sim_share_dir, "standalone_resource", "logo.png")
-    param_file = os.path.join(rosflight_sim_share_dir, 'params', 'standalone_sim_params.yaml')
+    rviz2_splash_file = PathJoinSubstitution(
+        [rosflight_sim_share, 'standalone_resource', 'logo.png']
+    )
+    param_file = PathJoinSubstitution([rosflight_sim_share, 'params', 'standalone_sim_params.yaml'])
 
     sim_aircraft_file = LaunchConfiguration('sim_aircraft_file')
     sim_aircraft_file_launch_arg = DeclareLaunchArgument(
         'sim_aircraft_file',
-        default_value=TextSubstitution(text=os.path.join("common_resource", "multirotor.dae")),
+        default_value="common_resource/multirotor.dae",
         description="Path to the .dae file that defines the simulation mesh to visualize."
     )
 
@@ -34,44 +35,28 @@ def generate_launch_description():
                 package="tf2_ros",
                 executable="static_transform_publisher",
                 arguments=[
-                    "--x",
-                    "0",
-                    "--y",
-                    "0",
-                    "--z",
-                    "0",
-                    "--yaw",
-                    "0",
-                    "--pitch",
-                    "0",
-                    "--roll",
-                    "3.1415926535",
-                    "--frame-id",
-                    "world",
-                    "--child-frame-id",
-                    "NED",
+                    *["--x", "0"],
+                    *["--y", "0"],
+                    *["--z", "0"],
+                    *["--yaw", "0"],
+                    *["--pitch", "0"],
+                    *["--roll", "3.1415926535"],
+                    *["--frame-id", "world"],
+                    *["--child-frame-id", "NED"],
                 ],
             ),
             Node(
                 package="tf2_ros",
                 executable="static_transform_publisher",
                 arguments=[
-                    "--x",
-                    "0",
-                    "--y",
-                    "0",
-                    "--z",
-                    "0",
-                    "--yaw",
-                    "-1.570796326",
-                    "--pitch",
-                    "0",
-                    "--roll",
-                    "3.1415926535",
-                    "--frame-id",
-                    "aircraft_body",
-                    "--child-frame-id",
-                    "stl_frame",
+                    *["--x", "0"],
+                    *["--y", "0"],
+                    *["--z", "0"],
+                    *["--yaw", "-1.570796326"],
+                    *["--pitch", "0"],
+                    *["--roll", "3.1415926535"],
+                    *["--frame-id", "aircraft_body"],
+                    *["--child-frame-id", "stl_frame"],
                 ],
             ),
             Node(

--- a/rosflight_sim/simulators/standalone_sim/src/standalone_viz_transcriber.cpp
+++ b/rosflight_sim/simulators/standalone_sim/src/standalone_viz_transcriber.cpp
@@ -38,8 +38,8 @@
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <rclcpp/rclcpp.hpp>
-#include <tf2/LinearMath/Quaternion.h>
-#include <tf2_ros/transform_broadcaster.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2_ros/transform_broadcaster.hpp>
 #include <visualization_msgs/msg/marker.hpp>
 
 #include "standalone_viz_transcriber.hpp"

--- a/rosflight_sim/simulators/standalone_sim/src/standalone_viz_transcriber.cpp
+++ b/rosflight_sim/simulators/standalone_sim/src/standalone_viz_transcriber.cpp
@@ -34,7 +34,6 @@
 #include <cstdint>
 #include <vector>
 
-#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <rclcpp/rclcpp.hpp>

--- a/rosflight_sim/src/forces_and_moments_interface.cpp
+++ b/rosflight_sim/src/forces_and_moments_interface.cpp
@@ -35,6 +35,8 @@
 
 #include "rosflight_sim/forces_and_moments_interface.hpp"
 
+#include "rosflight_compat/service_client.hpp"
+
 namespace rosflight_sim
 {
 
@@ -66,8 +68,11 @@ ForcesAndMomentsInterface::ForcesAndMomentsInterface()
 
   // Service clients
   client_cb_group_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-  firmware_param_get_client_ = this->create_client<rosflight_msgs::srv::ParamGet>("param_get", rclcpp::ServicesQoS(), client_cb_group_);
-  firmware_check_param_client_ = this->create_client<std_srvs::srv::Trigger>("all_params_received", rclcpp::ServicesQoS(), client_cb_group_);
+  firmware_param_get_client_ =
+    rosflight_compat::create_service_client<rosflight_msgs::srv::ParamGet>(*this, "sil_board/run",
+                                                                           client_cb_group_);
+  firmware_check_param_client_ = rosflight_compat::create_service_client<std_srvs::srv::Trigger>(
+    *this, "all_params_received", client_cb_group_);
 
   // Request mixer values on boot
   do_initialize_parameters_ = true;

--- a/rosflight_sim/src/forces_and_moments_interface.cpp
+++ b/rosflight_sim/src/forces_and_moments_interface.cpp
@@ -224,9 +224,11 @@ bool ForcesAndMomentsInterface::send_check_params_service_to_firmware()
 void ForcesAndMomentsInterface::invert_matrix(Eigen::Matrix<double, NUM_MIXER_OUTPUTS, NUM_MIXER_OUTPUTS> &mixer_to_invert)
 {
   // Calculate the pseudoinverse of the mixing matrix using the SVD
+  auto flags = static_cast<unsigned int>(Eigen::FullPivHouseholderQRPreconditioner)
+    | static_cast<unsigned int>(Eigen::ComputeFullU)
+    | static_cast<unsigned int>(Eigen::ComputeFullV);
   Eigen::JacobiSVD<Eigen::Matrix<double, NUM_MIXER_OUTPUTS, NUM_MIXER_OUTPUTS>> svd(
-    mixer_to_invert,
-    Eigen::FullPivHouseholderQRPreconditioner | Eigen::ComputeFullU | Eigen::ComputeFullV);
+    mixer_to_invert, flags);
   Eigen::Matrix<double, NUM_MIXER_OUTPUTS, NUM_MIXER_OUTPUTS> Sig;
   Sig.setZero();
 

--- a/rosflight_sim/src/forces_and_moments_interface.cpp
+++ b/rosflight_sim/src/forces_and_moments_interface.cpp
@@ -66,8 +66,8 @@ ForcesAndMomentsInterface::ForcesAndMomentsInterface()
 
   // Service clients
   client_cb_group_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-  firmware_param_get_client_ = this->create_client<rosflight_msgs::srv::ParamGet>("param_get", rmw_qos_profile_services_default, client_cb_group_);
-  firmware_check_param_client_ = this->create_client<std_srvs::srv::Trigger>("all_params_received", rmw_qos_profile_services_default, client_cb_group_);
+  firmware_param_get_client_ = this->create_client<rosflight_msgs::srv::ParamGet>("param_get", rclcpp::ServicesQoS(), client_cb_group_);
+  firmware_check_param_client_ = this->create_client<std_srvs::srv::Trigger>("all_params_received", rclcpp::ServicesQoS(), client_cb_group_);
 
   // Request mixer values on boot
   do_initialize_parameters_ = true;

--- a/rosflight_sim/src/rosflight_sil.cpp
+++ b/rosflight_sim/src/rosflight_sil.cpp
@@ -55,7 +55,7 @@ ROSflightSIL::ROSflightSIL()
 
   // Initialize the service clients that will be used
   client_cb_group_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-  firmware_run_client_ = this->create_client<std_srvs::srv::Trigger>("sil_board/run", rmw_qos_profile_services_default, client_cb_group_);
+  firmware_run_client_ = this->create_client<std_srvs::srv::Trigger>("sil_board/run", rclcpp::ServicesQoS(), client_cb_group_);
 
   // Initialize the timer if the parameter is set to be so
   if (this->get_parameter("use_timer").as_bool()) {

--- a/rosflight_sim/src/rosflight_sil.cpp
+++ b/rosflight_sim/src/rosflight_sil.cpp
@@ -34,6 +34,8 @@
 
 #include <chrono>
 
+#include "rosflight_compat/service_client.hpp"
+
 #include "rosflight_sim/rosflight_sil.hpp"
 
 using namespace std::chrono_literals;
@@ -55,7 +57,8 @@ ROSflightSIL::ROSflightSIL()
 
   // Initialize the service clients that will be used
   client_cb_group_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-  firmware_run_client_ = this->create_client<std_srvs::srv::Trigger>("sil_board/run", rclcpp::ServicesQoS(), client_cb_group_);
+  firmware_run_client_ = rosflight_compat::create_service_client<std_srvs::srv::Trigger>(
+    *this, "sil_board/run", client_cb_group_);
 
   // Initialize the timer if the parameter is set to be so
   if (this->get_parameter("use_timer").as_bool()) {

--- a/rosflight_sim/src/rosflight_sil.cpp
+++ b/rosflight_sim/src/rosflight_sil.cpp
@@ -101,8 +101,9 @@ void ROSflightSIL::reset_timers()
   }
 }
 
-bool ROSflightSIL::iterate_simulation(const std_srvs::srv::Trigger::Request::SharedPtr & req,
-                                      const std_srvs::srv::Trigger::Response::SharedPtr & res)
+bool ROSflightSIL::iterate_simulation(
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr & req,
+  const std_srvs::srv::Trigger::Response::SharedPtr & res)
 {
   res->success = call_firmware();
 

--- a/rosflight_sim/src/sil_board_ros.cpp
+++ b/rosflight_sim/src/sil_board_ros.cpp
@@ -77,8 +77,9 @@ void SILBoardROS::initialize_members()
   firmware_->init();
 }
 
-bool SILBoardROS::run_firmware(const std_srvs::srv::Trigger::Request::SharedPtr & req,  
-                               const std_srvs::srv::Trigger::Response::SharedPtr & res)
+bool SILBoardROS::run_firmware(
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr & req,
+  const std_srvs::srv::Trigger::Response::SharedPtr & res)
 {
   if (!is_initialized_) {
     initialize_members();

--- a/rosflight_sim/src/time_manager_interface.cpp
+++ b/rosflight_sim/src/time_manager_interface.cpp
@@ -139,6 +139,7 @@ bool TimeManagerInterface::toggle_pause_callback(
     RCLCPP_INFO_STREAM(this->get_logger(), "Timer is paused!");
   }
 
+  res->success = true;
   return true;
 }
 

--- a/rosflight_sim/src/time_manager_interface.cpp
+++ b/rosflight_sim/src/time_manager_interface.cpp
@@ -120,8 +120,9 @@ void TimeManagerInterface::publish_sim_time()
   sim_time_pubber_->publish(now);
 }
 
-bool TimeManagerInterface::toggle_pause_callback(const std_srvs::srv::Trigger::Request::SharedPtr & req,
-                                                 const std_srvs::srv::Trigger::Response::SharedPtr & res)
+bool TimeManagerInterface::toggle_pause_callback(
+  [[maybe_unused]] const std_srvs::srv::Trigger::Request::SharedPtr & req,
+  const std_srvs::srv::Trigger::Response::SharedPtr & res)
 {
   if (is_paused_) {
     // Unpause and restart the timer to continue publishing time information

--- a/rosflight_sim/src/udp_board.cpp
+++ b/rosflight_sim/src/udp_board.cpp
@@ -35,6 +35,7 @@
  */
 
 #include "rosflight_sim/udp_board.hpp"
+#include <boost/asio/io_context.hpp>
 
 using boost::asio::ip::udp;
 
@@ -46,8 +47,8 @@ UDPBoard::UDPBoard(std::string bind_host, uint16_t bind_port, std::string remote
     , bind_port_(bind_port)
     , remote_host_(std::move(remote_host))
     , remote_port_(remote_port)
-    , io_service_()
-    , socket_(io_service_)
+    , io_context_()
+    , socket_(io_context_)
     , write_in_progress_(false)
 {}
 
@@ -56,7 +57,7 @@ UDPBoard::~UDPBoard()
   MutexLock read_lock(read_mutex_);
   MutexLock write_lock(write_mutex_);
 
-  io_service_.stop();
+  io_context_.stop();
   socket_.close();
 
   if (io_thread_.joinable()) {
@@ -78,12 +79,12 @@ void UDPBoard::serial_init(uint32_t baud_rate, uint32_t dev)
   // can throw an uncaught boost::system::system_error exception
   (void) dev;
 
-  udp::resolver resolver(io_service_);
+  udp::resolver resolver(io_context_);
 
-  bind_endpoint_ = *resolver.resolve({udp::v4(), bind_host_, ""});
+  bind_endpoint_ = resolver.resolve(udp::v4(), bind_host_, "").begin()->endpoint();
   bind_endpoint_.port(bind_port_);
 
-  remote_endpoint_ = *resolver.resolve({udp::v4(), remote_host_, ""});
+  remote_endpoint_ = resolver.resolve(udp::v4(), remote_host_, "").begin()->endpoint();
   remote_endpoint_.port(remote_port_);
 
   socket_.open(udp::v4());
@@ -94,7 +95,7 @@ void UDPBoard::serial_init(uint32_t baud_rate, uint32_t dev)
   socket_.set_option(udp::socket::receive_buffer_size(1000 * MAVLINK_MAX_PACKET_LEN));
 
   async_read();
-  io_thread_ = boost::thread(boost::bind(&boost::asio::io_service::run, &io_service_));
+  io_thread_ = boost::thread(boost::bind(&boost::asio::io_context::run, &io_context_));
 }
 
 void UDPBoard::serial_flush() {}


### PR DESCRIPTION
## Summary

Update the ROSflight ROS packages for ROS 2 Lyrical / Ubuntu 26.04 compatibility with clean builds.

## Changes

- Update Docker configuration from ROS 2 Humble to ROS 2 Lyrical.
- Update Docker setup for the Ubuntu 26.04 default `ubuntu` user and current package names.
- Bump CMake minimum versions to `3.20...3.28`.
- Replace deprecated `ament_target_dependencies` usage with imported CMake targets.
- Update Boost.Asio usage for newer Boost APIs.
- Update tf2 include paths and add the missing `tf2_geometry_msgs` dependency.
- Replace deprecated `get_package_share_directory` usage with `get_package_share_path` and ROS 2 launch substitutions.
- Replace deprecated QoS and Eigen enum usage.
- Update mavlink include paths to match the current firmware layout.
- Remove deprecated metadata, unused headers, and unused-variable warnings.
- Suppress the current Eigen `maybe-uninitialized` warning emitted from firmware mixer code.
- ~~Apply CMake formatting cleanup and run `./fix_code_style.sh` to format C++ sources.~~ (removed after talking to Jacob - so it can be done after several PRs are merged)

## Notes

Ubuntu 26.04 ships with CMake 4.2, but enabling the latest CMake policies currently exposes GCC-related build issues. This PR sets the CMake policy range upper bound to 3.28, matching the CMake version available on Ubuntu 24.04, and leaves room to raise the upper bound later once those policy/compiler issues are resolved.

## Testing

- `colcon build` completes successfully without warnings.