### PR TITLE
Modernize CMake

### DIFF
--- a/rosflight_compat/CMakeLists.txt
+++ b/rosflight_compat/CMakeLists.txt
@@ -21,8 +21,8 @@ set_target_properties(rosflight_compat_headers PROPERTIES
   EXPORT_NAME compat_headers
 )
 target_include_directories(rosflight_compat_headers INTERFACE
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 )
 target_link_libraries(rosflight_compat_headers INTERFACE
   ament_index_cpp::ament_index_cpp
@@ -36,14 +36,14 @@ target_link_libraries(rosflight_compat_headers INTERFACE
 # Headers for exported/public libraries
 install(
   DIRECTORY include/
-  DESTINATION "include/${PROJECT_NAME}"
+  DESTINATION include/${PROJECT_NAME}
 )
 
 # Exported/public libraries
 install(
   TARGETS
     rosflight_compat_headers
-  EXPORT "export_${PROJECT_NAME}"
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -54,7 +54,7 @@ install(
 ########################
 
 # Export public libraries
-ament_export_targets("export_${PROJECT_NAME}" HAS_LIBRARY_TARGET)
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 
 # Export public cmake package dependencies (not targets)
 ament_export_dependencies(rclcpp)

--- a/rosflight_compat/CMakeLists.txt
+++ b/rosflight_compat/CMakeLists.txt
@@ -57,6 +57,9 @@ install(
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 
 # Export public cmake package dependencies (not targets)
-ament_export_dependencies(rclcpp)
+ament_export_dependencies(
+  rclcpp
+  ament_index_cpp
+)
 
 ament_package()

--- a/rosflight_gcs/CMakeLists.txt
+++ b/rosflight_gcs/CMakeLists.txt
@@ -1,15 +1,6 @@
 cmake_minimum_required(VERSION 3.20...3.28)
 project(rosflight_gcs)
 
-if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
-endif()
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
-
-add_compile_options(-Wall)
-
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
 endif()
@@ -20,48 +11,46 @@ find_package(geometry_msgs REQUIRED)
 find_package(rosflight_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(visualization_msgs REQUIRED)
-find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 
-include_directories(include)
+#################
+## Executables ##
+#################
 
 # viz executable
 add_executable(viz src/viz.cpp)
+target_compile_features(viz PRIVATE cxx_std_17)
+target_compile_options(viz PRIVATE -Wall)
+target_include_directories(viz PRIVATE include)
 target_link_libraries(viz PRIVATE
   rclcpp::rclcpp
   geometry_msgs::geometry_msgs
   rosflight_msgs::rosflight_msgs
   sensor_msgs::sensor_msgs
-  tf2::tf2
   tf2_geometry_msgs::tf2_geometry_msgs
   visualization_msgs::visualization_msgs
 )
 
-# Install header files
-install(
-  DIRECTORY include
-  DESTINATION include
-)
+#############
+## Install ##
+#############
 
-# Install executables
+# C++ nodes/executables
 install(
   TARGETS viz
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
   RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 
-# Install launch files
+# Resources
 install(
-  DIRECTORY launch
+  DIRECTORY
+    launch
+    rviz
   DESTINATION share/${PROJECT_NAME}
-  FILES_MATCHING PATTERN "*.py"
 )
 
-# Install rviz files
-install(
-  DIRECTORY rviz
-  DESTINATION share/${PROJECT_NAME}
-)
+######################
+## ROS Finalization ##
+######################
 
 ament_package()

--- a/rosflight_gcs/package.xml
+++ b/rosflight_gcs/package.xml
@@ -22,7 +22,6 @@
   <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>visualization_msgs</depend>
-  <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
 
   <depend>rosflight_msgs</depend>

--- a/rosflight_io/CMakeLists.txt
+++ b/rosflight_io/CMakeLists.txt
@@ -14,8 +14,7 @@ find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(message_filters REQUIRED)
-
-find_package(Boost CONFIG REQUIRED COMPONENTS thread)
+find_package(Threads REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
@@ -64,6 +63,7 @@ add_library(mavrosflight
 add_library(rosflight_io::mavrosflight ALIAS mavrosflight)
 target_compile_features(mavrosflight PUBLIC cxx_std_17)
 target_compile_options(mavrosflight PRIVATE -Wno-address-of-packed-member -Wall)
+target_compile_definitions(mavrosflight PUBLIC ASIO_STANDALONE)
 target_include_directories(mavrosflight PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:> # intentionally left blank since not exported
@@ -72,10 +72,9 @@ target_link_libraries(mavrosflight
   PUBLIC
     rosflight_firmware::mavlink_headers
     rclcpp::rclcpp
-    Boost::headers
-    Boost::thread
   PRIVATE
     yaml-cpp::yaml-cpp
+    Threads::Threads
 )
 
 # realtime_configurator library (exported)
@@ -87,9 +86,12 @@ target_include_directories(realtime_configurator PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 )
-target_link_libraries(realtime_configurator PUBLIC
-  rclcpp::rclcpp
-  std_msgs::std_msgs
+target_link_libraries(realtime_configurator
+  PUBLIC
+    rclcpp::rclcpp
+    std_msgs::std_msgs
+  PRIVATE
+    Threads::Threads
 )
 
 #################
@@ -116,7 +118,6 @@ target_link_libraries(rosflight_io PRIVATE
   std_msgs::std_msgs
   std_srvs::std_srvs
   tf2_geometry_msgs::tf2_geometry_msgs
-  Boost::headers
   Eigen3::Eigen
 )
 
@@ -176,8 +177,6 @@ ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_dependencies(
   rclcpp
   std_msgs
-  Boost
-  # asio
 )
 
 ament_package()

--- a/rosflight_io/CMakeLists.txt
+++ b/rosflight_io/CMakeLists.txt
@@ -13,7 +13,6 @@ find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
-find_package(message_filters REQUIRED)
 find_package(Threads REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(yaml-cpp REQUIRED)
@@ -50,8 +49,8 @@ add_subdirectory(
 ## Libraries ##
 ###############
 
-# mavrosflight library (internal to this file - not exported)
-add_library(mavrosflight
+# mavrosflight (private helper for rosflight_io executable - not exported)
+add_library(mavrosflight STATIC
   src/mavrosflight/mavrosflight.cpp
   src/mavrosflight/mavlink_comm.cpp
   src/mavrosflight/mavlink_serial.cpp
@@ -77,8 +76,8 @@ target_link_libraries(mavrosflight
     Threads::Threads
 )
 
-# realtime_configurator library (exported)
-add_library(realtime_configurator src/realtime_configurator.cpp)
+# realtime_configurator (exported for use in other packages)
+add_library(realtime_configurator SHARED src/realtime_configurator.cpp)
 add_library(rosflight_io::realtime_configurator ALIAS realtime_configurator)
 target_compile_features(realtime_configurator PUBLIC cxx_std_17)
 target_compile_options(realtime_configurator PRIVATE -Wall)
@@ -135,14 +134,6 @@ install(
 install(
   TARGETS realtime_configurator
   EXPORT export_${PROJECT_NAME}
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)
-
-# Private runtime libraries, installed but not exported
-install(
-  TARGETS mavrosflight
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin

--- a/rosflight_io/CMakeLists.txt
+++ b/rosflight_io/CMakeLists.txt
@@ -1,15 +1,6 @@
 cmake_minimum_required(VERSION 3.20...3.28)
 project(rosflight_io)
 
-if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
-endif()
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
-
-add_compile_options(-Wall)
-
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
 endif()
@@ -21,7 +12,6 @@ find_package(rosflight_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
-find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(message_filters REQUIRED)
 
@@ -38,19 +28,22 @@ if(NOT TARGET yaml-cpp::yaml-cpp)
   )
 endif()
 
-# clone firmware submodule if it is missing
-set(firmware_submodule_dir "${CMAKE_CURRENT_SOURCE_DIR}/../rosflight_firmware")
-if(NOT EXISTS "${firmware_submodule_dir}/.git")
-  message(STATUS "Firmware submodule not found at ${firmware_submodule_dir}")
-  execute_process(
-    COMMAND git submodule update --init --recursive
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+##############
+## Firmware ##
+##############
+
+set(firmware_submodule_dir ${CMAKE_CURRENT_SOURCE_DIR}/../rosflight_firmware)
+if(NOT EXISTS ${firmware_submodule_dir}/.git)
+  message(FATAL_ERROR
+    "Firmware submodule not found at ${firmware_submodule_dir}.\n"
+    "You may need to run `git submodule update --init --recursive` "
+    "inside of rosflight_ros_pkgs."
   )
 endif()
 
 add_subdirectory(
-  "${firmware_submodule_dir}"
-  "${CMAKE_CURRENT_BINARY_DIR}/rosflight_firmware"
+  ${firmware_submodule_dir}
+  ${CMAKE_CURRENT_BINARY_DIR}/rosflight_firmware
   EXCLUDE_FROM_ALL  # prevent compilation of unused targets
 )
 
@@ -58,7 +51,7 @@ add_subdirectory(
 ## Libraries ##
 ###############
 
-# mavrosflight library
+# mavrosflight library (internal to this file - not exported)
 add_library(mavrosflight
   src/mavrosflight/mavrosflight.cpp
   src/mavrosflight/mavlink_comm.cpp
@@ -68,38 +61,53 @@ add_library(mavrosflight
   src/mavrosflight/param.cpp
   src/mavrosflight/time_manager.cpp
 )
-target_compile_options(mavrosflight PRIVATE -Wno-address-of-packed-member)
-target_link_libraries(mavrosflight PRIVATE
-  rclcpp::rclcpp
-  yaml-cpp::yaml-cpp
-  Boost::headers
-  Boost::thread
+add_library(rosflight_io::mavrosflight ALIAS mavrosflight)
+target_compile_features(mavrosflight PUBLIC cxx_std_17)
+target_compile_options(mavrosflight PRIVATE -Wno-address-of-packed-member -Wall)
+target_include_directories(mavrosflight PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:> # intentionally left blank since not exported
+)
+target_link_libraries(mavrosflight
+  PUBLIC
+    rosflight_firmware::mavlink_headers
+    rclcpp::rclcpp
+    Boost::headers
+    Boost::thread
+  PRIVATE
+    yaml-cpp::yaml-cpp
 )
 
-# realtime_configurator library
-add_library(realtime_configurator SHARED
-  src/realtime_configurator.cpp
-)
+# realtime_configurator library (exported)
+add_library(realtime_configurator src/realtime_configurator.cpp)
+add_library(rosflight_io::realtime_configurator ALIAS realtime_configurator)
+target_compile_features(realtime_configurator PUBLIC cxx_std_17)
+target_compile_options(realtime_configurator PRIVATE -Wall)
 target_include_directories(realtime_configurator PUBLIC
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>"
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 )
-target_link_libraries(realtime_configurator PRIVATE
+target_link_libraries(realtime_configurator PUBLIC
   rclcpp::rclcpp
   std_msgs::std_msgs
 )
-ament_export_targets(export_realtime_configurator HAS_LIBRARY_TARGET)
 
-# rosflight_io_node
+#################
+## Executables ##
+#################
+
+# rosflight_io node
 add_executable(rosflight_io
   src/rosflight_io_node.cpp
   src/rosflight_io.cpp
   src/magnetometer_calibration.cpp
 )
-target_compile_options(rosflight_io PRIVATE -Wno-address-of-packed-member)
+target_compile_features(rosflight_io PRIVATE cxx_std_17)
+target_compile_options(rosflight_io PRIVATE -Wno-address-of-packed-member -Wall)
+target_include_directories(rosflight_io PRIVATE include)
 target_link_libraries(rosflight_io PRIVATE
-  mavrosflight
-  realtime_configurator
+  rosflight_io::mavrosflight
+  rosflight_io::realtime_configurator
   rosflight_firmware::version
   rclcpp::rclcpp
   geometry_msgs::geometry_msgs
@@ -107,7 +115,6 @@ target_link_libraries(rosflight_io PRIVATE
   sensor_msgs::sensor_msgs
   std_msgs::std_msgs
   std_srvs::std_srvs
-  tf2::tf2
   tf2_geometry_msgs::tf2_geometry_msgs
   Boost::headers
   Eigen3::Eigen
@@ -117,30 +124,60 @@ target_link_libraries(rosflight_io PRIVATE
 ## Install ##
 #############
 
-# Mark executables and libraries for installation
-install(TARGETS mavrosflight rosflight_io
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
+# Headers for exported/public libraries
+install(
+  FILES include/rosflight_io/realtime_configurator.hpp
+  DESTINATION include/${PROJECT_NAME}/rosflight_io
 )
 
-# Mark cpp header files for installation
-install(DIRECTORY include/rosflight_io/mavrosflight/
-  DESTINATION include/${PROJECT_NAME}
-  FILES_MATCHING PATTERN "*.h"
-  PATTERN ".svn" EXCLUDE
-)
-
-install(TARGETS realtime_configurator
-  EXPORT export_realtime_configurator
+# Exported/public libraries
+install(
+  TARGETS realtime_configurator
+  EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
-  INCLUDES DESTINATION include
 )
 
-install(FILES include/rosflight_io/realtime_configurator.hpp
-  DESTINATION include
+# Private runtime libraries, installed but not exported
+install(
+  TARGETS mavrosflight
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+# C++ nodes/executables
+install(
+  TARGETS rosflight_io
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+##################
+# ROS Finalization
+##################
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+# Export public libraries
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+
+# Export public cmake package dependencies (not targets)
+ament_export_dependencies(
+  rclcpp
+  std_msgs
+  Boost
+  # asio
 )
 
 ament_package()

--- a/rosflight_io/CMakeLists.txt
+++ b/rosflight_io/CMakeLists.txt
@@ -39,43 +39,24 @@ if(NOT TARGET yaml-cpp::yaml-cpp)
 endif()
 
 # clone firmware submodule if it is missing
-set(FIRMWARE_SUBMODULE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../rosflight_firmware")
-if(NOT EXISTS "${FIRMWARE_SUBMODULE_DIR}/.git")
-  message(STATUS "Firmware submodule not found at ${FIRMWARE_SUBMODULE_DIR}")
+set(firmware_submodule_dir "${CMAKE_CURRENT_SOURCE_DIR}/../rosflight_firmware")
+if(NOT EXISTS "${firmware_submodule_dir}/.git")
+  message(STATUS "Firmware submodule not found at ${firmware_submodule_dir}")
   execute_process(
     COMMAND git submodule update --init --recursive
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   )
 endif()
 
-set(FIRMWARE_INCLUDE_DIRS
-  ../rosflight_firmware/include/
-  ../rosflight_firmware/include/interface/
-  ../rosflight_firmware/lib/
-  ../rosflight_firmware/comms/
+add_subdirectory(
+  "${firmware_submodule_dir}"
+  "${CMAKE_CURRENT_BINARY_DIR}/rosflight_firmware"
+  EXCLUDE_FROM_ALL  # prevent compilation of unused targets
 )
 
-# Determine ROSflight version
-execute_process(
-  COMMAND git describe --tags --abbrev=8 --always --dirty --long
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  OUTPUT_VARIABLE GIT_VERSION_STRING RESULT_VARIABLE GIT_RESULT
-)
-if(GIT_RESULT EQUAL 0)
-  string(REGEX REPLACE "\n$" "" GIT_VERSION_STRING "${GIT_VERSION_STRING}") # remove trailing newline
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DROSFLIGHT_VERSION=${GIT_VERSION_STRING}")
-else()
-  message("Could not determine rosflight version through git")
-endif()
-
-
-###########
-## Build ##
-###########
-
-include_directories(include
-  ${FIRMWARE_INCLUDE_DIRS}
-)
+###############
+## Libraries ##
+###############
 
 # mavrosflight library
 add_library(mavrosflight
@@ -119,6 +100,7 @@ target_compile_options(rosflight_io PRIVATE -Wno-address-of-packed-member)
 target_link_libraries(rosflight_io PRIVATE
   mavrosflight
   realtime_configurator
+  rosflight_firmware::version
   rclcpp::rclcpp
   geometry_msgs::geometry_msgs
   rosflight_msgs::rosflight_msgs

--- a/rosflight_io/include/rosflight_io/mavrosflight/mavlink_bridge.hpp
+++ b/rosflight_io/include/rosflight_io/mavrosflight/mavlink_bridge.hpp
@@ -39,6 +39,6 @@
 #ifndef MAVROSFLIGHT_MAVLINK_BRIDGE_H
 #define MAVROSFLIGHT_MAVLINK_BRIDGE_H
 
-#include <mavlink/mavlink.h>
+#include <rosflight/mavlink.h>
 
 #endif // MAVROSFLIGHT_MAVLINK_BRIDGE_H

--- a/rosflight_io/include/rosflight_io/mavrosflight/mavlink_comm.hpp
+++ b/rosflight_io/include/rosflight_io/mavrosflight/mavlink_comm.hpp
@@ -40,14 +40,13 @@
 #include <rosflight_io/mavrosflight/mavlink_bridge.hpp>
 #include <rosflight_io/mavrosflight/mavlink_listener_interface.hpp>
 
-#include <boost/asio.hpp>
-#include <boost/function.hpp>
-#include <boost/thread.hpp>
+#include <asio.hpp>
 
 #include <cstdint>
-#include <iostream>
+#include <functional>
 #include <list>
-#include <string>
+#include <mutex>
+#include <thread>
 #include <vector>
 
 #define MAVLINK_SERIAL_READ_BUF_SIZE 256
@@ -101,14 +100,12 @@ protected:
   virtual bool is_open() = 0;
   virtual void do_open() = 0;
   virtual void do_close() = 0;
-  virtual void
-  do_async_read(const boost::asio::mutable_buffer & buffer,
-                boost::function<void(const boost::system::error_code &, size_t)> handler) = 0;
-  virtual void
-  do_async_write(const boost::asio::const_buffer & buffer,
-                 boost::function<void(const boost::system::error_code &, size_t)> handler) = 0;
+  virtual void do_async_read(const asio::mutable_buffer & buffer,
+                             std::function<void(const asio::error_code &, size_t)> handler) = 0;
+  virtual void do_async_write(const asio::const_buffer & buffer,
+                              std::function<void(const asio::error_code &, size_t)> handler) = 0;
 
-  boost::asio::io_context io_context_; //!< boost io context provider
+  asio::io_context io_context_; //!< asio io context provider
 
 private:
   //===========================================================================
@@ -145,7 +142,7 @@ private:
   /**
    * \brief Convenience typedef for mutex lock
    */
-  typedef boost::lock_guard<boost::recursive_mutex> mutex_lock;
+  typedef std::lock_guard<std::recursive_mutex> mutex_lock;
 
   //===========================================================================
   // methods
@@ -161,7 +158,7 @@ private:
    * \param error Error code
    * \param bytes_transferred Number of bytes received
    */
-  void async_read_end(const boost::system::error_code & error, size_t bytes_transferred);
+  void async_read_end(const asio::error_code & error, size_t bytes_transferred);
 
   /**
    * \brief Initialize an asynchronous write operation
@@ -174,7 +171,7 @@ private:
    * \param error Error code
    * \param bytes_transferred Number of bytes sent
    */
-  void async_write_end(const boost::system::error_code & error, size_t bytes_transferred);
+  void async_write_end(const asio::error_code & error, size_t bytes_transferred);
 
   //===========================================================================
   // member variables
@@ -182,8 +179,8 @@ private:
 
   std::vector<MavlinkListenerInterface *> listeners_; //!< listeners for mavlink messages
 
-  boost::thread io_thread_;      //!< thread on which the io service runs
-  boost::recursive_mutex mutex_; //!< mutex for threadsafe operation
+  std::thread io_thread_;      //!< thread on which the io service runs
+  std::recursive_mutex mutex_; //!< mutex for threadsafe operation
 
   uint8_t read_buf_raw_[MAVLINK_SERIAL_READ_BUF_SIZE];
 

--- a/rosflight_io/include/rosflight_io/mavrosflight/mavlink_serial.hpp
+++ b/rosflight_io/include/rosflight_io/mavrosflight/mavlink_serial.hpp
@@ -39,9 +39,9 @@
 
 #include <rosflight_io/mavrosflight/mavlink_comm.hpp>
 
-#include <boost/asio.hpp>
-#include <boost/function.hpp>
+#include <asio.hpp>
 
+#include <functional>
 #include <string>
 
 namespace mavrosflight
@@ -73,23 +73,21 @@ private:
   /**
    * \brief Initiate an asynchronous read operation
    */
-  void
-  do_async_read(const boost::asio::mutable_buffer & buffer,
-                boost::function<void(const boost::system::error_code &, size_t)> handler) override;
+  void do_async_read(const asio::mutable_buffer & buffer,
+                     std::function<void(const asio::error_code &, size_t)> handler) override;
 
   /**
    * \brief Initialize an asynchronous write operation
    * \param check_write_state If true, only start another write operation if a write sequence is not already running
    */
-  void
-  do_async_write(const boost::asio::const_buffer & buffer,
-                 boost::function<void(const boost::system::error_code &, size_t)> handler) override;
+  void do_async_write(const asio::const_buffer & buffer,
+                      std::function<void(const asio::error_code &, size_t)> handler) override;
 
   //===========================================================================
   // member variables
   //===========================================================================
 
-  boost::asio::serial_port serial_port_; //!< boost serial port object
+  asio::serial_port serial_port_; //!< asio serial port object
 
   std::string port_;
   int baud_rate_;

--- a/rosflight_io/include/rosflight_io/mavrosflight/mavlink_udp.hpp
+++ b/rosflight_io/include/rosflight_io/mavrosflight/mavlink_udp.hpp
@@ -39,9 +39,9 @@
 
 #include <rosflight_io/mavrosflight/mavlink_comm.hpp>
 
-#include <boost/asio.hpp>
-#include <boost/function.hpp>
+#include <asio.hpp>
 
+#include <functional>
 #include <string>
 
 namespace mavrosflight
@@ -72,12 +72,10 @@ private:
   bool is_open() override;
   void do_open() override;
   void do_close() override;
-  void
-  do_async_read(const boost::asio::mutable_buffer & buffer,
-                boost::function<void(const boost::system::error_code &, size_t)> handler) override;
-  void
-  do_async_write(const boost::asio::const_buffer & buffer,
-                 boost::function<void(const boost::system::error_code &, size_t)> handler) override;
+  void do_async_read(const asio::mutable_buffer & buffer,
+                     std::function<void(const asio::error_code &, size_t)> handler) override;
+  void do_async_write(const asio::const_buffer & buffer,
+                      std::function<void(const asio::error_code &, size_t)> handler) override;
 
   //===========================================================================
   // member variables
@@ -89,9 +87,9 @@ private:
   std::string remote_host_;
   uint16_t remote_port_;
 
-  boost::asio::ip::udp::socket socket_;
-  boost::asio::ip::udp::endpoint bind_endpoint_;
-  boost::asio::ip::udp::endpoint remote_endpoint_;
+  asio::ip::udp::socket socket_;
+  asio::ip::udp::endpoint bind_endpoint_;
+  asio::ip::udp::endpoint remote_endpoint_;
 };
 
 } // namespace mavrosflight

--- a/rosflight_io/include/rosflight_io/mavrosflight/mavrosflight.hpp
+++ b/rosflight_io/include/rosflight_io/mavrosflight/mavrosflight.hpp
@@ -47,8 +47,6 @@
 
 #include <rclcpp/rclcpp.hpp>
 
-#include <boost/function.hpp>
-
 #include <cstdint>
 #include <string>
 

--- a/rosflight_io/include/rosflight_io/mavrosflight/serial_exception.hpp
+++ b/rosflight_io/include/rosflight_io/mavrosflight/serial_exception.hpp
@@ -41,12 +41,10 @@
 #include <sstream>
 #include <string>
 
-#include <boost/system/system_error.hpp>
-
 namespace mavrosflight
 {
 /**
- * \brief Describes an exception encountered while using the boost serial libraries
+ * \brief Describes an exception encountered while using serial communication
  */
 class SerialException : public std::exception
 {
@@ -55,7 +53,7 @@ public:
 
   explicit SerialException(const std::string & description) { init(description.c_str()); }
 
-  explicit SerialException(const boost::system::system_error & err) { init(err.what()); }
+  explicit SerialException(const std::system_error & err) { init(err.what()); }
 
   SerialException(const SerialException & other)
       : what_(other.what_)

--- a/rosflight_io/package.xml
+++ b/rosflight_io/package.xml
@@ -25,9 +25,7 @@
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
-  <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
-  <depend>message_filters</depend>
 
   <!-- system libraries -->
   <depend>boost</depend>

--- a/rosflight_io/package.xml
+++ b/rosflight_io/package.xml
@@ -28,7 +28,7 @@
   <depend>tf2_geometry_msgs</depend>
 
   <!-- system libraries -->
-  <depend>boost</depend>
+  <depend>asio</depend>
   <depend>eigen</depend>
   <depend>yaml-cpp</depend>
 

--- a/rosflight_io/src/mavrosflight/mavlink_comm.cpp
+++ b/rosflight_io/src/mavrosflight/mavlink_comm.cpp
@@ -36,9 +36,10 @@
 
 #include <rosflight_io/mavrosflight/mavlink_comm.hpp>
 
+#include <iostream>
+
 namespace mavrosflight
 {
-using boost::asio::serial_port_base;
 
 MavlinkComm::MavlinkComm()
     : io_context_()
@@ -57,7 +58,7 @@ void MavlinkComm::open()
 
   // start reading from the port
   async_read();
-  io_thread_ = boost::thread(boost::bind(&boost::asio::io_context::run, &this->io_context_));
+  io_thread_ = std::thread([this]() {io_context_.run();});
 }
 
 void MavlinkComm::close()
@@ -111,12 +112,13 @@ void MavlinkComm::async_read()
     return;
   }
 
-  do_async_read(boost::asio::buffer(read_buf_raw_, MAVLINK_SERIAL_READ_BUF_SIZE),
-                boost::bind(&MavlinkComm::async_read_end, this, boost::asio::placeholders::error,
-                            boost::asio::placeholders::bytes_transferred));
+  do_async_read(asio::buffer(read_buf_raw_, MAVLINK_SERIAL_READ_BUF_SIZE),
+                [this](const asio::error_code & error, size_t bytes_transferred) {
+                  async_read_end(error, bytes_transferred);
+                });
 }
 
-void MavlinkComm::async_read_end(const boost::system::error_code & error, size_t bytes_transferred)
+void MavlinkComm::async_read_end(const asio::error_code & error, size_t bytes_transferred)
 {
   if (!is_open()) {
     return;
@@ -165,13 +167,13 @@ void MavlinkComm::async_write(bool check_write_state)
 
   write_in_progress_ = true;
   WriteBuffer * buffer = write_queue_.front();
-  do_async_write(boost::asio::buffer(buffer->dpos(), buffer->nbytes()),
-                 boost::bind(&MavlinkComm::async_write_end, this, boost::asio::placeholders::error,
-                             boost::asio::placeholders::bytes_transferred));
+  do_async_write(asio::buffer(buffer->dpos(), buffer->nbytes()),
+                 [this](const asio::error_code & error, size_t bytes_transferred) {
+                   async_write_end(error, bytes_transferred);
+                 });
 }
 
-void MavlinkComm::async_write_end(const boost::system::error_code & error,
-                                  std::size_t bytes_transferred)
+void MavlinkComm::async_write_end(const asio::error_code & error, std::size_t bytes_transferred)
 {
   if (error) {
     std::cerr << error.message() << std::endl;

--- a/rosflight_io/src/mavrosflight/mavlink_serial.cpp
+++ b/rosflight_io/src/mavrosflight/mavlink_serial.cpp
@@ -37,9 +37,11 @@
 #include <rosflight_io/mavrosflight/mavlink_serial.hpp>
 #include <rosflight_io/mavrosflight/serial_exception.hpp>
 
+#include <asio.hpp>
+
 namespace mavrosflight
 {
-using boost::asio::serial_port_base;
+using asio::serial_port_base;
 
 MavlinkSerial::MavlinkSerial(std::string port, int baud_rate)
     : MavlinkComm()
@@ -61,23 +63,21 @@ void MavlinkSerial::do_open()
     serial_port_.set_option(serial_port_base::parity(serial_port_base::parity::none));
     serial_port_.set_option(serial_port_base::stop_bits(serial_port_base::stop_bits::one));
     serial_port_.set_option(serial_port_base::flow_control(serial_port_base::flow_control::none));
-  } catch (const boost::system::system_error & e) {
+  } catch (const asio::system_error & e) {
     throw SerialException(e);
   }
 }
 
 void MavlinkSerial::do_close() { serial_port_.close(); }
 
-void MavlinkSerial::do_async_read(
-  const boost::asio::mutable_buffer & buffer,
-  boost::function<void(const boost::system::error_code &, size_t)> handler)
+void MavlinkSerial::do_async_read(const asio::mutable_buffer & buffer,
+                                  std::function<void(const asio::error_code &, size_t)> handler)
 {
   serial_port_.async_read_some(buffer, handler);
 }
 
-void MavlinkSerial::do_async_write(
-  const boost::asio::const_buffer & buffer,
-  boost::function<void(const boost::system::error_code &, size_t)> handler)
+void MavlinkSerial::do_async_write(const asio::const_buffer & buffer,
+                                   std::function<void(const asio::error_code &, size_t)> handler)
 {
   serial_port_.async_write_some(buffer, handler);
 }

--- a/rosflight_io/src/mavrosflight/mavlink_udp.cpp
+++ b/rosflight_io/src/mavrosflight/mavlink_udp.cpp
@@ -37,11 +37,10 @@
 #include <rosflight_io/mavrosflight/mavlink_udp.hpp>
 #include <rosflight_io/mavrosflight/serial_exception.hpp>
 
-using boost::asio::ip::udp;
+using asio::ip::udp;
 
 namespace mavrosflight
 {
-using boost::asio::serial_port_base;
 
 MavlinkUDP::MavlinkUDP(std::string bind_host, uint16_t bind_port, std::string remote_host,
                        uint16_t remote_port)
@@ -74,23 +73,21 @@ void MavlinkUDP::do_open()
     socket_.set_option(udp::socket::reuse_address(true));
     socket_.set_option(udp::socket::send_buffer_size(1000 * MAVLINK_MAX_PACKET_LEN));
     socket_.set_option(udp::socket::receive_buffer_size(1000 * MAVLINK_SERIAL_READ_BUF_SIZE));
-  } catch (const boost::system::system_error & e) {
+  } catch (const asio::system_error & e) {
     throw SerialException(e);
   }
 }
 
 void MavlinkUDP::do_close() { socket_.close(); }
 
-void MavlinkUDP::do_async_read(
-  const boost::asio::mutable_buffer & buffer,
-  boost::function<void(const boost::system::error_code &, size_t)> handler)
+void MavlinkUDP::do_async_read(const asio::mutable_buffer & buffer,
+                               std::function<void(const asio::error_code &, size_t)> handler)
 {
   socket_.async_receive_from(buffer, remote_endpoint_, handler);
 }
 
-void MavlinkUDP::do_async_write(
-  const boost::asio::const_buffer & buffer,
-  boost::function<void(const boost::system::error_code &, size_t)> handler)
+void MavlinkUDP::do_async_write(const asio::const_buffer & buffer,
+                                std::function<void(const asio::error_code &, size_t)> handler)
 {
   socket_.async_send_to(buffer, remote_endpoint_, handler);
 }

--- a/rosflight_io/src/mavrosflight/mavrosflight.cpp
+++ b/rosflight_io/src/mavrosflight/mavrosflight.cpp
@@ -38,7 +38,6 @@
 
 namespace mavrosflight
 {
-using boost::asio::serial_port_base;
 
 MavROSflight::MavROSflight(MavlinkComm & mavlink_comm, rclcpp::Node * const node)
     : comm(mavlink_comm)

--- a/rosflight_io/src/rosflight_io.cpp
+++ b/rosflight_io/src/rosflight_io.cpp
@@ -38,12 +38,6 @@
  * @author Brandon Sutherland <brandonsutherland2\@gmail.com>
  */
 
-#ifdef ROSFLIGHT_VERSION
-#define STRINGIFY(x) #x
-#define TOSTRING(x) STRINGIFY(x) // Somehow, C++ requires two macros to convert a macro to a string
-#define GIT_VERSION_STRING TOSTRING(ROSFLIGHT_VERSION)
-#endif
-
 #include <rosflight_io/mavrosflight/mavlink_serial.hpp>
 #include <rosflight_io/mavrosflight/mavlink_udp.hpp>
 #include <rosflight_io/mavrosflight/serial_exception.hpp>

--- a/rosflight_msgs/CMakeLists.txt
+++ b/rosflight_msgs/CMakeLists.txt
@@ -1,17 +1,6 @@
 cmake_minimum_required(VERSION 3.20...3.28)
 project(rosflight_msgs)
 
-if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
-endif()
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
-
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE "Release")
-endif()
-
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(builtin_interfaces REQUIRED)

--- a/rosflight_pkgs/CMakeLists.txt
+++ b/rosflight_pkgs/CMakeLists.txt
@@ -1,4 +1,12 @@
 cmake_minimum_required(VERSION 3.20...3.28)
 project(rosflight_pkgs)
+
+# Acknowledge variable does not need to be used since this file does not define
+# an executable (suppresses cmake warning)
+if(DEFINED CMAKE_EXPORT_COMPILE_COMMANDS)
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ${CMAKE_EXPORT_COMPILE_COMMANDS})
+endif()
+
 find_package(ament_cmake REQUIRED)
+
 ament_package()

--- a/rosflight_sim/CMakeLists.txt
+++ b/rosflight_sim/CMakeLists.txt
@@ -42,8 +42,8 @@ add_subdirectory(
 ## Libraries ##
 ###############
 
-# rosflight_sim::interfaces (exported for standalone_sim)
-add_library(rosflight_sim_interfaces
+# rosflight_sim::interfaces (exported for supported simulators)
+add_library(rosflight_sim_interfaces SHARED
   src/time_manager_interface.cpp
   src/forces_and_moments_interface.cpp
   src/sensor_interface.cpp

--- a/rosflight_sim/CMakeLists.txt
+++ b/rosflight_sim/CMakeLists.txt
@@ -30,86 +30,29 @@ find_package(Boost CONFIG REQUIRED COMPONENTS thread)
 ## Firmware ##
 ##############
 
+set(firmware_submodule_dir "${CMAKE_CURRENT_SOURCE_DIR}/../rosflight_firmware")
+
 # clone firmware submodule if it is missing
-set(FIRMWARE_SUBMODULE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../rosflight_firmware")
-if(NOT EXISTS "${FIRMWARE_SUBMODULE_DIR}/.git")
-  message(STATUS "Firmware submodule not found at ${FIRMWARE_SUBMODULE_DIR}")
+if(NOT EXISTS "${firmware_submodule_dir}/.git")
+  message(STATUS "Firmware submodule not found at ${firmware_submodule_dir}")
   execute_process(
     COMMAND git submodule update --init --recursive
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   )
 endif()
 
-set(FIRMWARE_INCLUDE_DIRS
-  ../rosflight_firmware/include/
-  ../rosflight_firmware/include/interface/
-  ../rosflight_firmware/lib/
-  ../rosflight_firmware/comms/mavlink
-  ../rosflight_firmware/comms/mavlink/v1.0
+add_subdirectory(
+  "${firmware_submodule_dir}"
+  "${CMAKE_CURRENT_BINARY_DIR}/rosflight_firmware"
 )
 
-include_directories(
-  ${FIRMWARE_INCLUDE_DIRS}
-)
+###############
+## Libraries ##
+###############
 
-# Git information
-execute_process(
-  COMMAND git rev-parse --short=8 HEAD
-  OUTPUT_VARIABLE GIT_VERSION_HASH
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/rosflight_firmware
 )
-
-execute_process(
-  COMMAND git describe --tags --abbrev=8 --always --dirty --long
-  OUTPUT_VARIABLE GIT_VERSION_STRING
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/rosflight_firmware
 )
-
-if("${GIT_VERSION_STRING}" STREQUAL "")
-  set(GIT_VERSION_STRING "undefined")
-endif()
-
-if("${GIT_VERSION_HASH}" STREQUAL "")
-  set(GIT_VERSION_HASH "0")
-endif()
-
-# rosflight_firmware
-add_library(rosflight_firmware
-  ${FIRMWARE_SUBMODULE_DIR}/src/rosflight.cpp
-  ${FIRMWARE_SUBMODULE_DIR}/src/estimator.cpp
-  ${FIRMWARE_SUBMODULE_DIR}/src/mixer.cpp
-  ${FIRMWARE_SUBMODULE_DIR}/src/controller.cpp
-  ${FIRMWARE_SUBMODULE_DIR}/src/param.cpp
-  ${FIRMWARE_SUBMODULE_DIR}/src/state_manager.cpp
-  ${FIRMWARE_SUBMODULE_DIR}/src/rc.cpp
-  ${FIRMWARE_SUBMODULE_DIR}/src/command_manager.cpp
-  ${FIRMWARE_SUBMODULE_DIR}/src/sensors.cpp
-  ${FIRMWARE_SUBMODULE_DIR}/src/comm_manager.cpp
-  ${FIRMWARE_SUBMODULE_DIR}/comms/mavlink/mavlink.cpp
-  ${FIRMWARE_SUBMODULE_DIR}/lib/turbomath/turbomath.cpp
 )
-target_include_directories(rosflight_firmware PRIVATE ${FIRMWARE_INCLUDE_DIRS})
-target_link_libraries(rosflight_firmware PRIVATE Eigen3::Eigen)
-# FIXME: Eigen currently prints a maybe-uninitialized warning for the invert_mixer()
-# function in mixer.cpp and this disables the warning. This warning may be fixed
-# in a future version of Eigen and the flag could be removed.
-target_compile_options(rosflight_firmware PRIVATE -Wno-maybe-uninitialized)
-target_compile_definitions(rosflight_firmware PUBLIC
-  GIT_VERSION_HASH=0x${GIT_VERSION_HASH}
-  GIT_VERSION_STRING=\"${GIT_VERSION_STRING}\"
-)
-ament_export_targets(rosflight_firmwareTargets HAS_LIBRARY_TARGET)
-install(
-  TARGETS rosflight_firmware
-  EXPORT rosflight_firmwareTargets
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-  RUNTIME DESTINATION bin
-  INCLUDES DESTINATION include
-)
-
 
 ###################
 ## ROSflight SIL ##
@@ -144,7 +87,7 @@ add_executable(sil_board
 )
 target_include_directories(sil_board PRIVATE include)
 target_link_libraries(sil_board PRIVATE
-  rosflight_firmware
+  rosflight_firmware::rosflight_firmware
   rclcpp::rclcpp
   std_srvs::std_srvs
   sensor_msgs::sensor_msgs

--- a/rosflight_sim/CMakeLists.txt
+++ b/rosflight_sim/CMakeLists.txt
@@ -1,24 +1,16 @@
 cmake_minimum_required(VERSION 3.20...3.28)
 project(rosflight_sim)
 
-if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
-endif()
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
-
-add_compile_options(-Wall -fPIC)
-
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(ament_cmake_python REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(rclpy REQUIRED)
 find_package(std_srvs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(rosgraph_msgs REQUIRED)
+find_package(geometry_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(rosflight_msgs REQUIRED)
 find_package(rosflight_compat REQUIRED)
@@ -30,36 +22,54 @@ find_package(Boost CONFIG REQUIRED COMPONENTS thread)
 ## Firmware ##
 ##############
 
-set(firmware_submodule_dir "${CMAKE_CURRENT_SOURCE_DIR}/../rosflight_firmware")
-
-# clone firmware submodule if it is missing
-if(NOT EXISTS "${firmware_submodule_dir}/.git")
-  message(STATUS "Firmware submodule not found at ${firmware_submodule_dir}")
-  execute_process(
-    COMMAND git submodule update --init --recursive
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+set(firmware_submodule_dir ${CMAKE_CURRENT_SOURCE_DIR}/../rosflight_firmware)
+if(NOT EXISTS ${firmware_submodule_dir}/.git)
+  message(FATAL_ERROR
+    "Firmware submodule not found at ${firmware_submodule_dir}.\n"
+    "You may need to run `git submodule update --init --recursive` "
+    "inside of rosflight_ros_pkgs."
   )
 endif()
 
 add_subdirectory(
-  "${firmware_submodule_dir}"
-  "${CMAKE_CURRENT_BINARY_DIR}/rosflight_firmware"
+  ${firmware_submodule_dir}
+  ${CMAKE_CURRENT_BINARY_DIR}/rosflight_firmware
 )
 
 ###############
 ## Libraries ##
 ###############
 
+# rosflight_sim::interfaces (exported for standalone_sim)
+add_library(rosflight_sim_interfaces
+  src/time_manager_interface.cpp
+  src/forces_and_moments_interface.cpp
+  src/sensor_interface.cpp
+  src/dynamics_interface.cpp
 )
+add_library(rosflight_sim::interfaces ALIAS rosflight_sim_interfaces)
+set_target_properties(rosflight_sim_interfaces PROPERTIES
+  EXPORT_NAME interfaces
+  POSITION_INDEPENDENT_CODE ON # needed for gazebo plugin
 )
+target_compile_features(rosflight_sim_interfaces PUBLIC cxx_std_17)
+target_compile_options(rosflight_sim_interfaces PRIVATE -Wall)
+target_include_directories(rosflight_sim_interfaces PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
 )
-
-###################
-## ROSflight SIL ##
-###################
-
-include_directories(include
-  ${SDFormat_INCLUDE_DIRS}
+target_link_libraries(rosflight_sim_interfaces
+  PUBLIC
+    rclcpp::rclcpp
+    std_srvs::std_srvs
+    std_msgs::std_msgs
+    rosgraph_msgs::rosgraph_msgs
+    geometry_msgs::geometry_msgs
+    sensor_msgs::sensor_msgs
+    rosflight_msgs::rosflight_msgs
+    Eigen3::Eigen
+  PRIVATE
+    rosflight_compat::compat_headers
 )
 
 ##################
@@ -68,6 +78,8 @@ include_directories(include
 
 # ROSflightSIL
 add_executable(rosflight_sil_manager src/rosflight_sil.cpp)
+target_compile_features(rosflight_sil_manager PRIVATE cxx_std_17)
+target_compile_options(rosflight_sil_manager PRIVATE -Wall)
 target_include_directories(rosflight_sil_manager PRIVATE include)
 target_link_libraries(rosflight_sil_manager PRIVATE
   rclcpp::rclcpp
@@ -75,9 +87,6 @@ target_link_libraries(rosflight_sil_manager PRIVATE
   rosflight_msgs::rosflight_msgs
   rosflight_compat::compat_headers
 )
-install(
-  TARGETS rosflight_sil_manager
-  DESTINATION lib/${PROJECT_NAME})
 
 # SILBoard
 add_executable(sil_board
@@ -85,6 +94,9 @@ add_executable(sil_board
   src/sil_board.cpp
   src/udp_board.cpp
 )
+target_compile_features(sil_board PRIVATE cxx_std_17)
+target_compile_options(sil_board PRIVATE -Wall)
+target_compile_definitions(sil_board PRIVATE ASIO_STANDALONE)
 target_include_directories(sil_board PRIVATE include)
 target_link_libraries(sil_board PRIVATE
   rosflight_firmware::rosflight_firmware
@@ -94,37 +106,39 @@ target_link_libraries(sil_board PRIVATE
   rosflight_msgs::rosflight_msgs
   Boost::thread
 )
-install(
-  TARGETS sil_board
-  DESTINATION lib/${PROJECT_NAME}
-)
 
 # Standalone simulator
 add_subdirectory(simulators/standalone_sim)
 
 # Optional simulator visualizers. These repositories may be cloned into the
 # rosflight_sim/simulators directory independently of rosflight_sim.
-set(ROSFIGHT_SIMULATORS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/simulators")
+set(rosfight_simulators_dir ${CMAKE_CURRENT_SOURCE_DIR}/simulators)
 
-set(ROSFIGHT_GAZEBO_CLASSIC_DIR "${ROSFIGHT_SIMULATORS_DIR}/rosflight_viz_gazebo_classic")
-if(EXISTS "${ROSFIGHT_GAZEBO_CLASSIC_DIR}/CMakeLists.txt")
+set(rosfight_gazebo_classic_dir
+  ${rosfight_simulators_dir}/rosflight_viz_gazebo_classic
+)
+if(EXISTS ${rosfight_gazebo_classic_dir}/CMakeLists.txt)
   if("$ENV{ROS_DISTRO}" STREQUAL "humble")
     add_subdirectory(simulators/rosflight_viz_gazebo_classic)
   else()
     message(WARNING
-      "rosflight_viz_gazebo_classic found, but Gazebo Classic visualizer is only built on ROS 2 Humble; skipping")
+      "rosflight_viz_gazebo_classic found, but Gazebo Classic visualizer is "
+      "only built on ROS 2 Humble; skipping"
+    )
   endif()
 endif()
 
-set(ROSFIGHT_GAZEBO_DIR "${ROSFIGHT_SIMULATORS_DIR}/rosflight_viz_gazebo")
-if(EXISTS "${ROSFIGHT_GAZEBO_DIR}/CMakeLists.txt")
+set(rosfight_gazebo_dir ${rosfight_simulators_dir}/rosflight_viz_gazebo)
+if(EXISTS ${rosfight_gazebo_dir}/CMakeLists.txt)
   add_subdirectory(simulators/rosflight_viz_gazebo)
 else()
-  message(WARNING "rosflight_viz_gazebo not found; skipping modern Gazebo visualizer")
+  message(WARNING
+    "rosflight_viz_gazebo not found; skipping modern Gazebo visualizer"
+  )
 endif()
 
-set(ROSFIGHT_HOLOOCEAN_DIR "${ROSFIGHT_SIMULATORS_DIR}/rosflight_viz_holoocean")
-if(EXISTS "${ROSFIGHT_HOLOOCEAN_DIR}/CMakeLists.txt")
+set(rosfight_holoocean_dir ${rosfight_simulators_dir}/rosflight_viz_holoocean)
+if(EXISTS ${rosfight_holoocean_dir}/CMakeLists.txt)
   add_subdirectory(simulators/rosflight_viz_holoocean)
 endif()
 
@@ -132,25 +146,68 @@ endif()
 ## Install ##
 #############
 
+# Headers for exported/public libraries
 install(
-  DIRECTORY params
-  DESTINATION share/${PROJECT_NAME}
+  FILES
+    include/rosflight_sim/time_manager_interface.hpp
+    include/rosflight_sim/forces_and_moments_interface.hpp
+    include/rosflight_sim/sensor_interface.hpp
+    include/rosflight_sim/dynamics_interface.hpp
+  DESTINATION include/${PROJECT_NAME}/rosflight_sim
 )
 
+# Exported/public libraries
 install(
-  DIRECTORY include/rosflight_sim
-  DESTINATION include/${PROJECT_NAME}
+  TARGETS
+    rosflight_sim_interfaces
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
+# C++ nodes/executables
 install(
-  DIRECTORY launch
-  DESTINATION share/${PROJECT_NAME}
-)
-
-install(PROGRAMS
-  src/rc.py
-  src/vimfly.py
+  TARGETS
+    rosflight_sil_manager
+    sil_board
   DESTINATION lib/${PROJECT_NAME}
+)
+
+# Python nodes/executables
+install(
+  PROGRAMS
+    src/rc.py
+    src/vimfly.py
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+# Resources
+install(
+  DIRECTORY
+    launch
+    params
+    simulators/common_resource
+  DESTINATION share/${PROJECT_NAME}
+)
+
+########################
+### ROS Finalization ###
+########################
+
+# Export public libraries
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+
+# Export public cmake package dependencies (not targets)
+ament_export_dependencies(
+  rclcpp
+  std_srvs
+  std_msgs
+  rosgraph_msgs
+  geometry_msgs
+  sensor_msgs
+  rosflight_msgs
+  Eigen3
 )
 
 ament_package()

--- a/rosflight_sim/CMakeLists.txt
+++ b/rosflight_sim/CMakeLists.txt
@@ -15,8 +15,10 @@ find_package(sensor_msgs REQUIRED)
 find_package(rosflight_msgs REQUIRED)
 find_package(rosflight_compat REQUIRED)
 find_package(Eigen3 REQUIRED)
-find_package(Boost CONFIG REQUIRED COMPONENTS thread)
+find_package(Threads REQUIRED)
 
+# throw error at cmake time rather than build time if libasio-dev not installed
+find_path(asio_INCLUDE_DIR asio.hpp REQUIRED)
 
 ##############
 ## Firmware ##
@@ -104,7 +106,7 @@ target_link_libraries(sil_board PRIVATE
   std_srvs::std_srvs
   sensor_msgs::sensor_msgs
   rosflight_msgs::rosflight_msgs
-  Boost::thread
+  Threads::Threads
 )
 
 # Standalone simulator

--- a/rosflight_sim/include/rosflight_sim/sil_board_ros.hpp
+++ b/rosflight_sim/include/rosflight_sim/sil_board_ros.hpp
@@ -77,7 +77,7 @@ private:
 
   // Components of the firmware
   std::shared_ptr<SILBoard> board_;
-  std::shared_ptr<rosflight_firmware::Mavlink> comm_;
+  std::shared_ptr<rosflight_firmware::MavlinkAdapter> comm_;
   std::shared_ptr<rosflight_firmware::ROSflight> firmware_;
 
   bool is_initialized_ = false;

--- a/rosflight_sim/include/rosflight_sim/udp_board.hpp
+++ b/rosflight_sim/include/rosflight_sim/udp_board.hpp
@@ -38,10 +38,11 @@
 #define ROSFLIGHT_SIM_UDP_BOARD_HPP
 
 #include <list>
+#include <mutex>
 #include <string>
+#include <thread>
 
-#include <boost/asio.hpp>
-#include <boost/thread.hpp>
+#include <asio.hpp>
 
 #include "board.h"
 #include "mavlink_adapter.hpp"
@@ -92,13 +93,13 @@ private:
     bool full() const { return len >= MAVLINK_MAX_PACKET_LEN; }
   };
 
-  typedef boost::lock_guard<boost::recursive_mutex> MutexLock;
+  typedef std::lock_guard<std::recursive_mutex> MutexLock;
 
   void async_read();
-  void async_read_end(const boost::system::error_code & error, size_t bytes_transferred);
+  void async_read_end(const asio::error_code & error, size_t bytes_transferred);
 
   void async_write(bool check_write_state);
-  void async_write_end(const boost::system::error_code & error, size_t bytes_transferred);
+  void async_write_end(const asio::error_code & error, size_t bytes_transferred);
 
   std::string bind_host_;
   uint16_t bind_port_;
@@ -106,15 +107,15 @@ private:
   std::string remote_host_;
   uint16_t remote_port_;
 
-  boost::thread io_thread_;
-  boost::recursive_mutex write_mutex_;
-  boost::recursive_mutex read_mutex_;
+  std::thread io_thread_;
+  std::recursive_mutex write_mutex_;
+  std::recursive_mutex read_mutex_;
 
-  boost::asio::io_context io_context_;
+  asio::io_context io_context_;
 
-  boost::asio::ip::udp::socket socket_;
-  boost::asio::ip::udp::endpoint bind_endpoint_;
-  boost::asio::ip::udp::endpoint remote_endpoint_;
+  asio::ip::udp::socket socket_;
+  asio::ip::udp::endpoint bind_endpoint_;
+  asio::ip::udp::endpoint remote_endpoint_;
 
   uint8_t read_buffer_[MAVLINK_MAX_PACKET_LEN] = {0};
   std::list<Buffer *> read_queue_;

--- a/rosflight_sim/include/rosflight_sim/udp_board.hpp
+++ b/rosflight_sim/include/rosflight_sim/udp_board.hpp
@@ -44,7 +44,7 @@
 #include <boost/thread.hpp>
 
 #include "board.h"
-#include "mavlink.h"
+#include "mavlink_adapter.hpp"
 
 namespace rosflight_sim
 {

--- a/rosflight_sim/package.xml
+++ b/rosflight_sim/package.xml
@@ -22,18 +22,24 @@
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <depend>rclcpp</depend>
-  <depend>rclpy</depend>
+  <depend>rclpy</depend> <!-- for holoocean sim -->
+  <depend>ament_index_cpp</depend> <!-- for standalone sim -->
 
+  <depend>std_srvs</depend>
+  <depend>std_msgs</depend>
+  <depend>rosgraph_msgs</depend>
   <depend>geometry_msgs</depend>
-  <depend>tf2_geometry_msgs</depend>
-  <depend>nav_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>tf2_geometry_msgs</depend> <!-- for standalone sim -->
+  <depend>tf2_ros</depend> <!-- for standalone sim -->
+  <depend>visualization_msgs</depend> <!-- for standalone sim -->
   <depend>rosflight_msgs</depend>
   <depend>rosflight_compat</depend>
   <depend>python3-pygame</depend>
   <depend>eigen</depend>
 
   <export>
-    <gazebo_ros plugin_path="${prefix}/lib" gazebo_media_path="${prefix}"/>
+    <gazebo_ros plugin_path="${prefix}/lib" gazebo_media_path="${prefix}" />
     <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/rosflight_sim/package.xml
+++ b/rosflight_sim/package.xml
@@ -21,6 +21,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
+  <build_depend>asio</build_depend>
+
   <depend>rclcpp</depend>
   <depend>rclpy</depend> <!-- for holoocean sim -->
   <depend>ament_index_cpp</depend> <!-- for standalone sim -->

--- a/rosflight_sim/simulators/standalone_sim/CMakeLists.txt
+++ b/rosflight_sim/simulators/standalone_sim/CMakeLists.txt
@@ -1,188 +1,127 @@
 cmake_minimum_required(VERSION 3.20...3.28)
 # Don't define own project -- use parent instead
 
-if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
-endif()
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
-
-add_compile_options(-Wall -fPIC)
-
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release")
 endif()
 
 # Find packages
 find_package(ament_cmake REQUIRED)
+find_package(ament_index_cpp REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rosflight_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(sensor_msgs REQUIRED)
-find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(visualization_msgs REQUIRED)
 
-# Rosflight Standalone sim
+#################
+## EXECUTABLES ##
+#################
+
+# Viz Transcriber
 add_executable(standalone_viz_transcriber src/standalone_viz_transcriber.cpp)
+target_compile_features(standalone_viz_transcriber PRIVATE cxx_std_17)
+target_compile_options(standalone_viz_transcriber PRIVATE -Wall)
 target_include_directories(standalone_viz_transcriber PRIVATE include)
 target_link_libraries(standalone_viz_transcriber PRIVATE
   ament_index_cpp::ament_index_cpp
   rclcpp::rclcpp
   geometry_msgs::geometry_msgs
   rosflight_msgs::rosflight_msgs
-  tf2::tf2
   tf2_ros::tf2_ros
   tf2_geometry_msgs::tf2_geometry_msgs
   visualization_msgs::visualization_msgs
 )
-ament_export_dependencies(rclcpp
-  tf2
-  tf2_ros
-  geometry_msgs
-  rosflight_msgs
-  visualization_msgs
-)
-install(
-  TARGETS standalone_viz_transcriber
-  DESTINATION lib/${PROJECT_NAME}
-)
 
 # Time Manager
-add_executable(standalone_time_manager
-  ../../src/time_manager_interface.cpp
-  src/standalone_time_manager.cpp
-)
-target_include_directories(standalone_time_manager PRIVATE
-  ../../include
-  include
-)
-target_link_libraries(standalone_time_manager PRIVATE
-  rclcpp::rclcpp
-  std_srvs::std_srvs
-)
-install(
-  TARGETS standalone_time_manager
-  DESTINATION lib/${PROJECT_NAME}
-)
+add_executable(standalone_time_manager src/standalone_time_manager.cpp)
+target_compile_features(standalone_time_manager PRIVATE cxx_std_17)
+target_compile_options(standalone_time_manager PRIVATE -Wall)
+target_include_directories(standalone_time_manager PRIVATE include)
+target_link_libraries(standalone_time_manager PRIVATE rosflight_sim::interfaces)
 
 # Multirotor Forces And Moments
 add_executable(multirotor_forces_and_moments
-  ../../src/forces_and_moments_interface.cpp
   src/multirotor_forces_and_moments.cpp
 )
-target_include_directories(multirotor_forces_and_moments PRIVATE
-  ../../include
-  include
-)
+target_compile_features(multirotor_forces_and_moments PRIVATE cxx_std_17)
+target_compile_options(multirotor_forces_and_moments PRIVATE -Wall)
+target_include_directories(multirotor_forces_and_moments PRIVATE include)
 target_link_libraries(multirotor_forces_and_moments PRIVATE
-rosflight_compat::compat_headers
-  rclcpp::rclcpp
-  std_srvs::std_srvs
+  rosflight_sim::interfaces
   geometry_msgs::geometry_msgs
   rosflight_msgs::rosflight_msgs
   Eigen3::Eigen
-)
-install(
-  TARGETS multirotor_forces_and_moments
-  DESTINATION lib/${PROJECT_NAME}
 )
 
 # FixedWing Forces And Moments
 add_executable(fixedwing_forces_and_moments
-  ../../src/forces_and_moments_interface.cpp
   src/fixedwing_forces_and_moments.cpp
 )
-target_include_directories(fixedwing_forces_and_moments PRIVATE
-  ../../include
-  include
-)
+target_compile_features(fixedwing_forces_and_moments PRIVATE cxx_std_17)
+target_compile_options(fixedwing_forces_and_moments PRIVATE -Wall)
+target_include_directories(fixedwing_forces_and_moments PRIVATE include)
 target_link_libraries(fixedwing_forces_and_moments PRIVATE
-  rosflight_compat::compat_headers
-  rclcpp::rclcpp
-  std_srvs::std_srvs
+  rosflight_sim::interfaces
   geometry_msgs::geometry_msgs
   rosflight_msgs::rosflight_msgs
   Eigen3::Eigen
-)
-install(
-  TARGETS fixedwing_forces_and_moments
-  DESTINATION lib/${PROJECT_NAME}
 )
 
 # Standalone Sensors
-add_executable(standalone_sensors
-  ../../src/sensor_interface.cpp
-  src/standalone_sensors.cpp
-)
-target_include_directories(standalone_sensors PRIVATE
-  include
-  simulators/standalone_sim/include
-)
+add_executable(standalone_sensors src/standalone_sensors.cpp)
+target_compile_features(standalone_sensors PRIVATE cxx_std_17)
+target_compile_options(standalone_sensors PRIVATE -Wall)
+target_include_directories(standalone_sensors PRIVATE include)
 target_link_libraries(standalone_sensors PRIVATE
+  rosflight_sim::interfaces
   rclcpp::rclcpp
-  sensor_msgs::sensor_msgs
   rosflight_msgs::rosflight_msgs
   geometry_msgs::geometry_msgs
   Eigen3::Eigen
 )
-install(
-  TARGETS standalone_sensors
-  DESTINATION lib/${PROJECT_NAME}
-)
 
 # Dynamics
-add_executable(standalone_dynamics
-  ../../src/dynamics_interface.cpp
-  src/standalone_dynamics.cpp
-)
-target_include_directories(standalone_dynamics PRIVATE
-  ../../include
-  include
-)
+add_executable(standalone_dynamics src/standalone_dynamics.cpp)
+target_compile_features(standalone_dynamics PRIVATE cxx_std_17)
+target_compile_options(standalone_dynamics PRIVATE -Wall)
+target_include_directories(standalone_dynamics PRIVATE include)
 target_link_libraries(standalone_dynamics PRIVATE
+  rosflight_sim::interfaces
   rclcpp::rclcpp
   rosflight_msgs::rosflight_msgs
   geometry_msgs::geometry_msgs
   tf2_geometry_msgs::tf2_geometry_msgs
-  std_srvs::std_srvs
   Eigen3::Eigen
 )
-ament_export_dependencies(standalone_dynamics
-  geometry_msgs
-  tf2_geometry_msgs
-  std_srvs
-  rclcpp
-  rosflight_msgs
-)
+
+#############
+## Install ##
+#############
+
+# C++ node executables
 install(
-  TARGETS standalone_dynamics
+  TARGETS
+    standalone_viz_transcriber
+    standalone_time_manager
+    multirotor_forces_and_moments
+    fixedwing_forces_and_moments
+    standalone_sensors
+    standalone_dynamics
   DESTINATION lib/${PROJECT_NAME}
 )
 
-
-# Other install
+# Resources
 install(
-  DIRECTORY launch
-  DESTINATION share/${PROJECT_NAME}
-)
-
-install(
-  DIRECTORY params
-  DESTINATION share/${PROJECT_NAME}
-)
-
-install(
-  DIRECTORY config
-  DESTINATION share/${PROJECT_NAME}
-)
-
-install(
-  DIRECTORY ../common_resource standalone_resource
+  DIRECTORY
+    launch
+    params
+    config
+    standalone_resource
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/rosflight_sim/src/sil_board_ros.cpp
+++ b/rosflight_sim/src/sil_board_ros.cpp
@@ -71,7 +71,7 @@ void SILBoardROS::initialize_members()
   board_ = std::make_shared<SILBoard>(node_ptr);
   board_->init_board();
 
-  comm_ = std::make_shared<rosflight_firmware::Mavlink>(*board_);
+  comm_ = std::make_shared<rosflight_firmware::MavlinkAdapter>(*board_);
   firmware_ = std::make_shared<rosflight_firmware::ROSflight>(*board_, *comm_);
 
   // Initialize the firmware

--- a/rosflight_sim/src/udp_board.cpp
+++ b/rosflight_sim/src/udp_board.cpp
@@ -35,9 +35,10 @@
  */
 
 #include "rosflight_sim/udp_board.hpp"
-#include <boost/asio/io_context.hpp>
 
-using boost::asio::ip::udp;
+#include <asio.hpp>
+
+using asio::ip::udp;
 
 namespace rosflight_sim
 {
@@ -74,10 +75,9 @@ void UDPBoard::set_ports(std::string bind_host, uint16_t bind_port, std::string 
   remote_port_ = remote_port;
 }
 
-void UDPBoard::serial_init(uint32_t baud_rate, uint32_t dev)
+void UDPBoard::serial_init(uint32_t baud_rate, [[maybe_unused]] uint32_t dev)
 {
-  // can throw an uncaught boost::system::system_error exception
-  (void) dev;
+  // can throw an uncaught asio::system_error exception
 
   udp::resolver resolver(io_context_);
 
@@ -95,7 +95,7 @@ void UDPBoard::serial_init(uint32_t baud_rate, uint32_t dev)
   socket_.set_option(udp::socket::receive_buffer_size(1000 * MAVLINK_MAX_PACKET_LEN));
 
   async_read();
-  io_thread_ = boost::thread(boost::bind(&boost::asio::io_context::run, &io_context_));
+  io_thread_ = std::thread([this]() { io_context_.run(); });
 }
 
 void UDPBoard::serial_flush() {}
@@ -144,12 +144,13 @@ void UDPBoard::async_read()
 
   MutexLock lock(read_mutex_);
   socket_.async_receive_from(
-    boost::asio::buffer(read_buffer_, MAVLINK_MAX_PACKET_LEN), remote_endpoint_,
-    boost::bind(&UDPBoard::async_read_end, this, boost::asio::placeholders::error,
-                boost::asio::placeholders::bytes_transferred));
+    asio::buffer(read_buffer_, MAVLINK_MAX_PACKET_LEN), remote_endpoint_,
+    [this](const asio::error_code & error, size_t bytes_transferred) {
+      async_read_end(error, bytes_transferred);
+    });
 }
 
-void UDPBoard::async_read_end(const boost::system::error_code & error, size_t bytes_transferred)
+void UDPBoard::async_read_end(const asio::error_code & error, size_t bytes_transferred)
 {
   if (!error) {
     MutexLock lock(read_mutex_);
@@ -171,13 +172,13 @@ void UDPBoard::async_write(bool check_write_state)
 
   write_in_progress_ = true;
   Buffer * buffer = write_queue_.front();
-  socket_.async_send_to(boost::asio::buffer(buffer->dpos(), buffer->nbytes()), remote_endpoint_,
-                        boost::bind(&UDPBoard::async_write_end, this,
-                                    boost::asio::placeholders::error,
-                                    boost::asio::placeholders::bytes_transferred));
+  socket_.async_send_to(asio::buffer(buffer->dpos(), buffer->nbytes()), remote_endpoint_,
+                        [this](const asio::error_code & error, size_t bytes_transferred) {
+                          async_write_end(error, bytes_transferred);
+                        });
 }
 
-void UDPBoard::async_write_end(const boost::system::error_code & error, size_t bytes_transferred)
+void UDPBoard::async_write_end(const asio::error_code & error, size_t bytes_transferred)
 {
   if (!error) {
     MutexLock lock(write_mutex_);


### PR DESCRIPTION
## Summary

Modernizes the ROS package CMake setup and updates ROSflight dependencies to use the firmware-provided CMake targets.

## Changes

- Replace manual firmware source/include wiring with `rosflight_firmware` CMake targets.
- Modernize target definitions, install rules, exported targets, and exported dependencies across packages.
- Replace Boost.Asio/Boost.Thread usage with standalone Asio and standard C++ threading primitives.
- Add/clean package dependencies for `rosflight_io`, `rosflight_sim`, standalone sim, and GCS.
- Preserve ROS 2 Humble compatibility for optional Gazebo Classic support.
- Advance the `rosflight_firmware` submodule from `3bbe3c9` to `e8cf6a0`.

## Notes

- `asio` is now required instead of Boost for the affected networking code.
- Missing firmware submodules now produce a CMake error with instructions instead of trying to initialize the submodule during configure.